### PR TITLE
Ian/ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ from a known good point as you iterate on the code.
 You can stop a migration from the CLI or dashboard, calling the component API directly:
 
 ```sh
-npx convex run --component migrations public:cancel '{"name": "migrations:myMigration"}'
+npx convex run --component migrations lib:cancel '{"name": "migrations:myMigration"}'
 ```
 
 Or via `migrations.cancel` programatically.
@@ -305,7 +305,7 @@ await migrations.cancel(ctx, internal.migrations.myMigration);
 To see the live status of migrations as they progress, you can query it via the CLI:
 
 ```sh
-npx convex run --component migrations public:getStatus --watch
+npx convex run --component migrations lib:getStatus --watch
 ```
 
 The `--watch` will live-update the status as it changes.

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -41,7 +41,7 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   migrations: {
-    public: {
+    lib: {
       cancel: FunctionReference<
         "mutation",
         "internal",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -187,7 +187,7 @@ export class Migrations<DataModel extends GenericDataModel> {
     }
     let status: MigrationStatus;
     try {
-      status = await ctx.runMutation(this.component.public.migrate, {
+      status = await ctx.runMutation(this.component.lib.migrate, {
         name,
         fnHandle,
         cursor: args.cursor,
@@ -438,7 +438,7 @@ export class Migrations<DataModel extends GenericDataModel> {
       dryRun?: boolean;
     }
   ) {
-    return ctx.runMutation(this.component.public.migrate, {
+    return ctx.runMutation(this.component.lib.migrate, {
       name: getFunctionName(fnRef),
       fnHandle: await createFunctionHandle(fnRef),
       cursor: opts?.cursor,
@@ -491,7 +491,7 @@ export class Migrations<DataModel extends GenericDataModel> {
         fnHandle: await createFunctionHandle(fnRef),
       }))
     );
-    return ctx.runMutation(this.component.public.migrate, {
+    return ctx.runMutation(this.component.lib.migrate, {
       name: getFunctionName(fnRef),
       fnHandle: await createFunctionHandle(fnRef),
       next,
@@ -519,7 +519,7 @@ export class Migrations<DataModel extends GenericDataModel> {
     const names = migrations?.map((m) =>
       typeof m === "string" ? this.prefixedName(m) : getFunctionName(m)
     );
-    return ctx.runQuery(this.component.public.getStatus, {
+    return ctx.runQuery(this.component.lib.getStatus, {
       names,
       limit,
     });
@@ -543,7 +543,7 @@ export class Migrations<DataModel extends GenericDataModel> {
       typeof migration === "string"
         ? this.prefixedName(migration)
         : getFunctionName(migration);
-    return ctx.runMutation(this.component.public.cancel, {
+    return ctx.runMutation(this.component.lib.cancel, {
       name,
     });
   }
@@ -557,7 +557,7 @@ export class Migrations<DataModel extends GenericDataModel> {
    * @returns The status of up to 100 of the canceled migrations.
    */
   async cancelAll(ctx: RunMutationCtx) {
-    return ctx.runMutation(this.component.public.cancelAll, {});
+    return ctx.runMutation(this.component.lib.cancelAll, {});
   }
 
   // Helper to prefix the name with the location.
@@ -663,12 +663,12 @@ function logStatusAndInstructions(
   if (!args.dryRun) {
     if (status.state === "inProgress") {
       output["toCancel"] = {
-        cmd: `${run} public:cancel`,
+        cmd: `${run} lib:cancel`,
         args: `{"name": "${name}"}`,
         prod: `--prod`,
       };
       output["toMonitorStatus"] = {
-        cmd: `${run} --watch public:getStatus`,
+        cmd: `${run} --watch lib:getStatus`,
         args: `{"names": ["${name}"${status.next?.length ? ", " + nextArgs : ""}]}`,
         prod: `--prod`,
       };
@@ -676,7 +676,7 @@ function logStatusAndInstructions(
       output["toStartOver"] = JSON.stringify({ ...args, cursor: null });
       if (status.next?.length) {
         output["toMonitorStatus"] = {
-          cmd: `${run} --watch public:getStatus`,
+          cmd: `${run} --watch lib:getStatus`,
           args: `{"names": [${nextArgs}]}`,
           prod: `--prod`,
         };

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import type * as public from "../public.js";
+import type * as lib from "../lib.js";
 
 import type {
   ApiFromModules,
@@ -26,10 +26,10 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
-  public: typeof public;
+  lib: typeof lib;
 }>;
 export type Mounts = {
-  public: {
+  lib: {
     cancel: FunctionReference<
       "mutation",
       "public",

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -114,7 +114,7 @@ export const migrate = mutation({
       // Step 3: Schedule the next batch or next migration.
       if (!state.isDone) {
         // Recursively schedule the next batch.
-        state.workerId = await ctx.scheduler.runAfter(0, api.public.migrate, {
+        state.workerId = await ctx.scheduler.runAfter(0, api.lib.migrate, {
           ...args,
           cursor: state.cursor,
         });
@@ -132,7 +132,7 @@ export const migrate = mutation({
           if (!doc || !doc.isDone) {
             const [nextFn, ...rest] = next.slice(i);
             if (nextFn) {
-              await ctx.scheduler.runAfter(0, api.public.migrate, {
+              await ctx.scheduler.runAfter(0, api.lib.migrate, {
                 name: nextFn.name,
                 fnHandle: nextFn.fnHandle,
                 next: rest,
@@ -305,7 +305,7 @@ export const cancelAll = mutation({
       )
       .take(100);
     if (results.length === 100) {
-      await ctx.scheduler.runAfter(0, api.public.cancelAll, {
+      await ctx.scheduler.runAfter(0, api.lib.cancelAll, {
         sinceTs: results[results.length - 1]!._creationTime,
       });
     }

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -39,6 +39,14 @@ export const migrate = mutation({
   handler: async (ctx, args) => {
     // Step 1: Get or create the state.
     const { fnHandle, batchSize, next: next_, dryRun, ...initialState } = args;
+    if (!fnHandle.startsWith("function://")) {
+      throw new Error(
+        "Invalid fnHandle.\n" +
+          "Do not call this from the CLI or dashboard directly.\n" +
+          "Instead use the `migrations.runner` function to run migrations." +
+          "See https://www.convex.dev/components/migrations"
+      );
+    }
     const state =
       (await ctx.db
         .query("migrations")

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,18 +1,19 @@
 import { Infer, ObjectType, v } from "convex/values";
 
 export const migrationArgs = {
+  fn: v.optional(v.string()),
   cursor: v.optional(v.union(v.string(), v.null())),
   batchSize: v.optional(v.number()),
   dryRun: v.optional(v.boolean()),
+  next: v.optional(v.array(v.string())),
 };
 export type MigrationArgs = ObjectType<typeof migrationArgs>;
 
-export const migrationResult = v.object({
-  continueCursor: v.string(),
-  isDone: v.boolean(),
-  processed: v.number(),
-});
-export type MigrationResult = Infer<typeof migrationResult>;
+export type MigrationResult = {
+  continueCursor: string;
+  isDone: boolean;
+  processed: number;
+};
 
 export const migrationStatus = v.object({
   name: v.string(),


### PR DESCRIPTION
<!-- Describe your PR here. -->

- rename `runMigration` to `migrate`
- allow calling your migrations directly like you used to be able to (with `fn`)
- improve some error messages

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
