### PR TITLE
improve logging and default handling

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -300,37 +300,30 @@ export class Migrations<DataModel extends GenericDataModel> {
           return (await this._runInteractive(ctx, args)) as any;
         } else if (args.next?.length) {
           throw new Error("You can only pass next if you also provide fn");
-        }
-        const numItems = args.batchSize || defaultBatchSize;
-        if (!args.batchSize) {
-          if (args.batchSize === 0) {
-            console.warn(`Batch size is zero. Using the default: ${numItems}`);
-          }
-          console.warn(
-            "Running this from the dashboard? Here's some args to use:"
-          );
-          console.warn({
-            "Dry run": '{ "dryRun": true, "cursor": null }',
-            "For real": '{ "fn": "path/to/migrations:yourFnName" }',
-          });
-        }
-        if (
-          (args.cursor === undefined || args.cursor === "") &&
-          args.dryRun === undefined
+        } else if (
+          args.cursor === undefined ||
+          args.cursor === "" ||
+          args.dryRun === undefined ||
+          args.batchSize === 0
         ) {
           console.warn(
-            "No cursor or dryRun specified - doing a dry run on the next batch" +
-              "Running this from the CLI or dashboard? Here's some args to use:"
+            "Running this from the CLI or dashboard? Here's some args to use:"
           );
           console.warn({
             "Dry run": '{ "dryRun": true, "cursor": null }',
             "For real": '{ "fn": "path/to/migrations:yourFnName" }',
           });
-          args.cursor = null;
-          args.dryRun = true;
         }
-        if (args.cursor === "" || args.cursor === undefined) {
-          if (args.dryRun) {
+
+        const numItems = args.batchSize || defaultBatchSize;
+        if (args.cursor === undefined || args.cursor === "") {
+          if (args.dryRun === undefined) {
+            console.warn(
+              "No cursor or dryRun specified - doing a dry run on the next batch."
+            );
+            args.cursor = null;
+            args.dryRun = true;
+          } else if (args.dryRun) {
             console.warn("Setting cursor to null for dry run");
             args.cursor = null;
           } else {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -39,6 +39,9 @@ export const migrate = mutation({
   handler: async (ctx, args) => {
     // Step 1: Get or create the state.
     const { fnHandle, batchSize, next: next_, dryRun, ...initialState } = args;
+    if (batchSize !== undefined && batchSize <= 0) {
+      throw new Error("Batch size must be greater than 0");
+    }
     if (!fnHandle.startsWith("function://")) {
       throw new Error(
         "Invalid fnHandle.\n" +


### PR DESCRIPTION
<!-- Describe your PR here. -->

Only print help when it's being called directly from the CLI /dashboard, without modifying other flows.
When it's called from the component, `cursor` is a string or null, `dryRun` is always a boolean. 
From the CLI / dashboard, they won't be set by default (though the dashboard used to set defaults like `cursor: ""` and `batchSize: 0` so we also check for that in case it comes back).

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
