### PR TITLE
Allow calling migration mutations directly

### DIFF
--- a/.agents/skills/convex/SKILL.md
+++ b/.agents/skills/convex/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: convex
+description: Routing skill for Convex work in this repo. Use when the user explicitly invokes the `convex` skill, asks which Convex workflow or skill to use, or says they are working on a Convex app without naming a specific task yet. Do not prefer this skill when the request is clearly about setting up Convex, authentication, components, migrations, or performance.
+---
+
+# Convex
+
+Use this as the routing skill for Convex work in this repo.
+
+If a more specific Convex skill clearly matches the request, use that instead.
+
+## Start Here
+
+If the project does not already have Convex AI guidance installed, or the existing guidance looks stale, strongly recommend installing it first.
+
+Preferred:
+
+```bash
+npx convex ai-files install
+```
+
+This installs or refreshes the managed Convex AI files. It is the recommended starting point for getting the official Convex guidelines in place and following the current Convex AI setup described in the docs:
+
+- [Convex AI docs](https://docs.convex.dev/ai)
+
+Simple fallback:
+
+- [convex_rules.txt](https://convex.link/convex_rules.txt)
+
+Prefer `npx convex ai-files install` over copying rules by hand when possible.
+
+## Route to the Right Skill
+
+After that, use the most specific Convex skill for the task:
+
+- New project or adding Convex to an app: `convex-quickstart`
+- Authentication setup: `convex-setup-auth`
+- Building a reusable Convex component: `convex-create-component`
+- Planning or running a migration: `convex-migration-helper`
+- Investigating performance issues: `convex-performance-audit`
+
+If one of those clearly matches the user's goal, switch to it instead of staying in this skill.
+
+## When Not to Use
+
+- The user has already named a more specific Convex workflow
+- Another Convex skill obviously fits the request better

--- a/.claude/skills/convex
+++ b/.claude/skills/convex
@@ -1,0 +1,1 @@
+../../.agents/skills/convex

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ You can also define a general-purpose runner that accepts a migration by name:
 export const run = migrations.runner();
 ```
 
+Then run it with the
+[function name](https://docs.convex.dev/functions/query-functions#query-names):
+
 ```sh
 npx convex run migrations:run '{fn: "migrations:setDefaultValue"}'
 ```

--- a/README.md
+++ b/README.md
@@ -402,24 +402,6 @@ await migrations.runOne(ctx, internal.migrations.clearField, {
 });
 ```
 
-### Automatic bandwidth management
-
-Migrations monitor transaction bandwidth usage during batch processing. If a
-batch approaches
-[transaction limits](https://docs.convex.dev/production/state/limits#transactions),
-it may stop early and let the remaining documents be picked up in the next
-batch.
-
-This helps avoid hitting limits when your `migrateOne` function performs
-expensive operations (reading related documents, writing to multiple tables,
-etc.).
-
-This works automatically with no configuration needed. If you frequently see
-batches ending early, consider reducing the batch size for that migration.
-
-**Note**: bandwidth monitoring is only available for sequential (non-parallel)
-batch processing.
-
 ### Parallelizing batches
 
 Each batch is processed serially, but within a batch you can have each

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ export const setDefaultValue = migrations.define({
 });
 ```
 
-You can then run it programmatically or from the CLI. See
+You can then run it directly from the CLI or programmatically. See
 [below](#running-migrations-one-at-a-time).
+
+```sh
+npx convex run migrations:setDefaultValue
+```
 
 Migrations allow you to define functions that run on all documents in a table
 (or a specified subset). They run in batches asynchronously (online migration).
@@ -155,34 +159,34 @@ export const validateRequiredField = migrations.define({
 
 ### Using the Dashboard or CLI
 
-To define a one-off function to run a single migration, pass a reference to it:
-
-```ts
-export const runIt = migrations.runner(internal.migrations.setDefaultValue);
-```
-
-To run it from the CLI:
+The simplest way to run a migration is to call it directly:
 
 ```sh
-npx convex run convex/migrations.ts:runIt # or shorthand: migrations:runIt
+npx convex run migrations:setDefaultValue
 ```
 
-**Note**: pass the `--prod` argument to run this and below commands in
-production
+The migration auto-detects its own function name, so no extra arguments are
+needed. Pass `--prod` to run in production.
 
 Running it from the dashboard:
 
 ![Dashboard screenshot](./dashboard_screenshot.png)
 
-You can also expose a general-purpose function to run your migrations. For
-example, in `convex/migrations.ts` add:
+You can also define a one-off runner for a specific migration:
+
+```ts
+export const runIt = migrations.runner(internal.migrations.setDefaultValue);
+```
+
+```sh
+npx convex run migrations:runIt
+```
+
+Or expose a general-purpose runner that accepts any migration by name:
 
 ```ts
 export const run = migrations.runner();
 ```
-
-Then run it with the
-[function name](https://docs.convex.dev/functions/query-functions#query-names):
 
 ```sh
 npx convex run migrations:run '{fn: "migrations:setDefaultValue"}'
@@ -407,6 +411,29 @@ await migrations.runOne(ctx, internal.migrations.clearField, {
   batchSize: 1,
 });
 ```
+
+### Automatic bandwidth management
+
+Migrations automatically monitor transaction bandwidth usage during batch
+processing. If a transaction exceeds 50% utilization on any metric (bytes
+read/written, documents read/written, etc.), the batch short-circuits early and
+retries the remaining documents in the next batch.
+
+This prevents hitting
+[transaction limits](https://docs.convex.dev/production/state/limits#transactions)
+when your `migrateOne` function performs expensive operations (reading related
+documents, writing to multiple tables, etc.). You'll see a log message like:
+
+```
+Short-circuiting batch after processing 30/100 documents due to transaction
+limits. 70 documents will be retried in the next batch.
+```
+
+This works automatically with no configuration needed. If you frequently see
+short-circuiting, consider reducing the batch size for that migration.
+
+**Note**: bandwidth monitoring is only available for sequential (non-parallel)
+batch processing.
 
 ### Parallelizing batches
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ import { components } from "./_generated/api.js";
 import { DataModel } from "./_generated/dataModel.js";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
-export const run = migrations.runner();
 ```
 
 The type parameter `DataModel` is optional. It provides type safety for
@@ -165,24 +164,13 @@ The simplest way to run a migration is to call it directly:
 npx convex run migrations:setDefaultValue
 ```
 
-The migration auto-detects its own function name, so no extra arguments are
-needed. Pass `--prod` to run in production.
+Pass `--prod` to run in production.
 
 Running it from the dashboard:
 
 ![Dashboard screenshot](./dashboard_screenshot.png)
 
-You can also define a one-off runner for a specific migration:
-
-```ts
-export const runIt = migrations.runner(internal.migrations.setDefaultValue);
-```
-
-```sh
-npx convex run migrations:runIt
-```
-
-Or expose a general-purpose runner that accepts any migration by name:
+You can also define a general-purpose runner that accepts a migration by name:
 
 ```ts
 export const run = migrations.runner();
@@ -224,7 +212,7 @@ should run on the next deployment.
 
 ### Using the Dashboard or CLI
 
-You can also pass a list of migrations to `runner` to have it run a series of
+You can pass a list of migrations to `runner` to have it run a series of
 migrations instead of just one:
 
 ```ts
@@ -241,11 +229,11 @@ Then just run:
 npx convex run migrations:runAll # migrations:runAll is equivalent to convex/migrations.ts:runAll on the CLI
 ```
 
-With the `runner` functions, you can pass a "next" argument to run a series of
-migrations after the first:
+When calling a migration directly, or with the `runner` functions, you can pass
+a "next" argument to run a series of migrations after the first:
 
 ```sh
-npx convex run migrations:runIt '{next:["migrations:clearField"]}'
+npx convex run migrations:setDefaultValue '{next:["migrations:clearField"]}'
 # OR
 npx convex run migrations:run '{fn: "migrations:setDefaultValue", next:["migrations:clearField"]}'
 ```
@@ -284,28 +272,30 @@ Before running a migration that may irreversibly change data, you can validate a
 batch by passing `dryRun` to any `runner` or `runOne` command:
 
 ```sh
-npx convex run migrations:runIt '{dryRun: true}'
+npx convex run migrations:setDefaultValue '{dryRun: true}'
 ```
 
 ### Restart a migration
 
-Pass `reset: true` to force a migration to start over from the beginning. This
+Pass `reset: true` to force a migration to start over from the beginning.
+
+```sh
+npx convex run migrations:setDefaultValue '{reset: true}'
+```
+
+If you specify `next` or run a defined series of migrations, this
 will reset the cursor for all migrations in the group.
 
 ```sh
-npx convex run migrations:runIt '{reset: true}'
-```
-
-Alternatively, you can pass `null` for the `cursor` to restart just the current
-migration:
-
-```sh
-npx convex run migrations:runIt '{cursor: null}'
+npx convex run migrations:runAll '{reset: true}'
 ```
 
 You can also pass in any valid cursor to start from. You can find valid cursors
 in the response of calls to `getStatus`. This can allow retrying a migration
 from a known good point as you iterate on the code.
+
+Note: if you're starting a migration from a specific cursor from the CLI or
+dashboard, do not pass `dryRun: false` explicitly, leave it undefined.
 
 ### Stop a migration
 
@@ -414,23 +404,18 @@ await migrations.runOne(ctx, internal.migrations.clearField, {
 
 ### Automatic bandwidth management
 
-Migrations automatically monitor transaction bandwidth usage during batch
-processing. If a transaction exceeds 50% utilization on any metric (bytes
-read/written, documents read/written, etc.), the batch short-circuits early and
-retries the remaining documents in the next batch.
+Migrations monitor transaction bandwidth usage during batch processing. If a
+batch approaches
+[transaction limits](https://docs.convex.dev/production/state/limits#transactions),
+it may stop early and let the remaining documents be picked up in the next
+batch.
 
-This prevents hitting
-[transaction limits](https://docs.convex.dev/production/state/limits#transactions)
-when your `migrateOne` function performs expensive operations (reading related
-documents, writing to multiple tables, etc.). You'll see a log message like:
-
-```
-Short-circuiting batch after processing 30/100 documents due to transaction
-limits. 70 documents will be retried in the next batch.
-```
+This helps avoid hitting limits when your `migrateOne` function performs
+expensive operations (reading related documents, writing to multiple tables,
+etc.).
 
 This works automatically with no configuration needed. If you frequently see
-short-circuiting, consider reducing the batch size for that migration.
+batches ending early, consider reducing the batch size for that migration.
 
 **Note**: bandwidth monitoring is only available for sequential (non-parallel)
 batch processing.

--- a/example/convex/_generated/ai/ai-files.state.json
+++ b/example/convex/_generated/ai/ai-files.state.json
@@ -1,9 +1,10 @@
 {
-  "guidelinesHash": "294b619f8246c26bd6bfb6a57122503f0e2149872fc6b26609b7a95bfefaf2b8",
+  "guidelinesHash": "62d72acb9afcc18f658d88dd772f34b5b1da5fa60ef0402e57a784d97c458e57",
   "agentsMdSectionHash": "42a9e7357f28f23a7ece5e63084a6c0a5b1dbc150b9f8e5ed046921a470a6320",
   "claudeMdHash": "42a9e7357f28f23a7ece5e63084a6c0a5b1dbc150b9f8e5ed046921a470a6320",
-  "agentSkillsSha": "dc8ff761cfe4da450af2ea8a9ec708f737064bed",
+  "agentSkillsSha": "231a67aa8a5b29cc2794cbc8298335a71aaa6d0e",
   "installedSkillNames": [
+    "convex",
     "convex-create-component",
     "convex-migration-helper",
     "convex-performance-audit",

--- a/example/convex/_generated/ai/guidelines.md
+++ b/example/convex/_generated/ai/guidelines.md
@@ -1,78 +1,90 @@
 # Convex guidelines
+
 ## Function guidelines
+
 ### Http endpoint syntax
+
 - HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+
 ```typescript
 import { httpRouter } from "convex/server";
 import { httpAction } from "./_generated/server";
 const http = httpRouter();
 http.route({
-    path: "/echo",
-    method: "POST",
-    handler: httpAction(async (ctx, req) => {
+  path: "/echo",
+  method: "POST",
+  handler: httpAction(async (ctx, req) => {
     const body = await req.bytes();
     return new Response(body, { status: 200 });
-    }),
+  }),
 });
 ```
+
 - HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
 
 ### Validators
+
 - Below is an example of an array validator:
+
 ```typescript
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 
 export default mutation({
-args: {
+  args: {
     simpleArray: v.array(v.union(v.string(), v.number())),
-},
-handler: async (ctx, args) => {
+  },
+  handler: async (ctx, args) => {
     //...
-},
+  },
 });
 ```
+
 - Below is an example of a schema with validators that codify a discriminated union type:
+
 ```typescript
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
-    results: defineTable(
-        v.union(
-            v.object({
-                kind: v.literal("error"),
-                errorMessage: v.string(),
-            }),
-            v.object({
-                kind: v.literal("success"),
-                value: v.number(),
-            }),
-        ),
-    )
+  results: defineTable(
+    v.union(
+      v.object({
+        kind: v.literal("error"),
+        errorMessage: v.string(),
+      }),
+      v.object({
+        kind: v.literal("success"),
+        value: v.number(),
+      }),
+    ),
+  ),
 });
 ```
+
 - Here are the valid Convex types along with their respective validators:
-Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
-| ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
-| Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
-| Int64       | bigint      | `3n`                   | `v.int64()`                                    | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers.                                                                                              |
-| Float64     | number      | `3.1`                  | `v.number()`                                   | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings.                                                                      |
-| Boolean     | boolean     | `true`                 | `v.boolean()`                                  |
-| String      | string      | `"abc"`                | `v.string()`                                   | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8.                                                         |
-| Bytes       | ArrayBuffer | `new ArrayBuffer(8)`   | `v.bytes()`                                    | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types.                                                     |
-| Array       | Array       | `[1, 3.2, "abc"]`      | `v.array(values)`                              | Arrays can have at most 8192 values.                                                                                                                                                                  |
-| Object      | Object      | `{a: "abc"}`           | `v.object({property: value})`                  | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
-| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |
+  Convex Type | TS/JS type | Example Usage | Validator for argument validation and schemas | Notes |
+  | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | Id | string | `doc._id` | `v.id(tableName)` | |
+  | Null | null | `null` | `v.null()` | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead. |
+  | Int64 | bigint | `3n` | `v.int64()` | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers. |
+  | Float64 | number | `3.1` | `v.number()` | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings. |
+  | Boolean | boolean | `true` | `v.boolean()` |
+  | String | string | `"abc"` | `v.string()` | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8. |
+  | Bytes | ArrayBuffer | `new ArrayBuffer(8)` | `v.bytes()` | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types. |
+  | Array | Array | `[1, 3.2, "abc"]` | `v.array(values)` | Arrays can have at most 8192 values. |
+  | Object | Object | `{a: "abc"}` | `v.object({property: value})` | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "\_". |
 
 ### Function registration
+
 - Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
 - Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
 - You CANNOT register a function through the `api` or `internal` objects.
 - ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.
 
 ### Function calling
+
 - Use `ctx.runQuery` to call a query from a query, mutation, or action.
 - Use `ctx.runMutation` to call a mutation from a mutation or action.
 - Use `ctx.runAction` to call an action from an action.
@@ -80,6 +92,7 @@ Convex Type  | TS/JS type  |  Example Usage         | Validator for argument val
 - Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
 - All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
 - When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
+
 ```
 export const f = query({
   args: { name: v.string() },
@@ -98,6 +111,7 @@ export const g = query({
 ```
 
 ### Function references
+
 - Use the `api` object defined by the framework in `convex/_generated/api.ts` to call public functions registered with `query`, `mutation`, or `action`.
 - Use the `internal` object defined by the framework in `convex/_generated/api.ts` to call internal (or private) functions registered with `internalQuery`, `internalMutation`, or `internalAction`.
 - Convex uses file-based routing, so a public function defined in `convex/example.ts` named `f` has a function reference of `api.example.f`.
@@ -105,6 +119,7 @@ export const g = query({
 - Functions can also registered within directories nested within the `convex/` folder. For example, a public function `h` defined in `convex/messages/access.ts` has a function reference of `api.messages.access.h`.
 
 ### Pagination
+
 - Define pagination using the following syntax:
 
 ```ts
@@ -112,17 +127,19 @@ import { v } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import { paginationOptsValidator } from "convex/server";
 export const listWithExtraArg = query({
-    args: { paginationOpts: paginationOptsValidator, author: v.string() },
-    handler: async (ctx, args) => {
-        return await ctx.db
-        .query("messages")
-        .withIndex("by_author", (q) => q.eq("author", args.author))
-        .order("desc")
-        .paginate(args.paginationOpts);
-    },
+  args: { paginationOpts: paginationOptsValidator, author: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("by_author", (q) => q.eq("author", args.author))
+      .order("desc")
+      .paginate(args.paginationOpts);
+  },
 });
 ```
+
 Note: `paginationOpts` is an object with the following properties:
+
 - `numItems`: the maximum number of documents to return (the validator is `v.number()`)
 - `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
 - A query that ends in `.paginate()` returns an object that has the following properties:
@@ -130,8 +147,8 @@ Note: `paginationOpts` is an object with the following properties:
 - isDone (a boolean that represents whether or not this is the last page of documents)
 - continueCursor (a string that represents the cursor to use to fetch the next page of documents)
 
-
 ## Schema guidelines
+
 - Always define your schema in `convex/schema.ts`.
 - Always import the schema definition functions from `convex/server`.
 - System fields are automatically added to all documents and are prefixed with an underscore. The two system fields that are automatically added to all documents are `_creationTime` which has the validator `v.number()` and `_id` which has the validator `v.id(tableName)`.
@@ -141,8 +158,10 @@ Note: `paginationOpts` is an object with the following properties:
 - Separate high-churn operational data (e.g. heartbeats, online status, typing indicators) from stable profile data. Storing frequently updated fields on a shared document forces every write to contend with reads of the entire document. Instead, create a dedicated table for the high-churn data with a foreign key back to the parent record.
 
 ## Authentication guidelines
+
 - Convex supports JWT-based authentication through `convex/auth.config.ts`. ALWAYS create this file when using authentication. Without it, `ctx.auth.getUserIdentity()` will always return `null`.
 - Example `convex/auth.config.ts`:
+
 ```typescript
 export default {
   providers: [
@@ -153,11 +172,14 @@ export default {
   ],
 };
 ```
+
 The `domain` must be the issuer URL of the JWT provider. Convex fetches `{domain}/.well-known/openid-configuration` to discover the JWKS endpoint. The `applicationID` is checked against the JWT `aud` (audience) claim.
+
 - Use `ctx.auth.getUserIdentity()` to get the authenticated user's identity in any query, mutation, or action. This returns `null` if the user is not authenticated, or a `UserIdentity` object with fields like `subject`, `issuer`, `name`, `email`, etc. The `subject` field is the unique user identifier.
 - In Convex `UserIdentity`, `tokenIdentifier` is guaranteed and is the canonical stable identifier for the authenticated identity. For any auth-linked database lookup or ownership check, prefer `identity.tokenIdentifier` over `identity.subject`. Do NOT use `identity.subject` alone as a global identity key.
 - NEVER accept a `userId` or any user identifier as a function argument for authorization purposes. Always derive the user identity server-side via `ctx.auth.getUserIdentity()`.
 - When using an external auth provider with Convex on the client, use `ConvexProviderWithAuth` instead of `ConvexProvider`:
+
 ```tsx
 import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
 
@@ -171,45 +193,51 @@ function App({ children }: { children: React.ReactNode }) {
   );
 }
 ```
+
 The `useAuth` prop must return `{ isLoading, isAuthenticated, fetchAccessToken }`. Do NOT use plain `ConvexProvider` when authentication is needed — it will not send tokens with requests.
 
 ## Typescript guidelines
-- You can use the helper typescript type `Id` imported from './_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
+
+- You can use the helper typescript type `Id` imported from './\_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
 - Use `Doc<"tableName">` from `./_generated/dataModel` to get the full document type for a table.
 - Use `QueryCtx`, `MutationCtx`, `ActionCtx` from `./_generated/server` for typing function contexts. NEVER use `any` for ctx parameters — always use the proper context type.
 - If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
+
 ```ts
 import { query } from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
 
 export const exampleQuery = query({
-    args: { userIds: v.array(v.id("users")) },
-    handler: async (ctx, args) => {
-        const idToUsername: Record<Id<"users">, string> = {};
-        for (const userId of args.userIds) {
-            const user = await ctx.db.get("users", userId);
-            if (user) {
-                idToUsername[user._id] = user.username;
-            }
-        }
+  args: { userIds: v.array(v.id("users")) },
+  handler: async (ctx, args) => {
+    const idToUsername: Record<Id<"users">, string> = {};
+    for (const userId of args.userIds) {
+      const user = await ctx.db.get("users", userId);
+      if (user) {
+        idToUsername[user._id] = user.username;
+      }
+    }
 
-        return idToUsername;
-    },
+    return idToUsername;
+  },
 });
 ```
+
 - Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
 
 ## Full text search guidelines
+
 - A query for "10 messages in channel '#general' that best match the query 'hello hi' in their body" would look like:
 
 const messages = await ctx.db
-  .query("messages")
-  .withSearchIndex("search_body", (q) =>
-    q.search("body", "hello hi").eq("channel", "#general"),
-  )
-  .take(10);
+.query("messages")
+.withSearchIndex("search_body", (q) =>
+q.search("body", "hello hi").eq("channel", "#general"),
+)
+.take(10);
 
 ## Query guidelines
+
 - Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
 - If the user does not explicitly tell you to return all results from a query you should ALWAYS return a bounded collection instead. So that is instead of using `.collect()` you should use `.take()` or paginate on database queries. This prevents future performance issues when tables grow in an unbounded way.
 - Never use `.collect().length` to count rows. Convex has no built-in count operator, so if you need a count that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations.
@@ -217,39 +245,46 @@ const messages = await ctx.db
 - Convex mutations are transactions with limits on the number of documents read and written. If a mutation needs to process more documents than fit in a single transaction (e.g. bulk deletion on a large table), process a batch with `.take(n)` and then call `ctx.scheduler.runAfter(0, api.myModule.myMutation, args)` to schedule itself to continue. This way each invocation stays within transaction limits.
 - Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.
 - When using async iteration, don't use `.collect()` or `.take(n)` on the result of a query. Instead, use the `for await (const row of query)` syntax.
+
 ### Ordering
+
 - By default Convex always returns documents in ascending `_creationTime` order.
 - You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
 - Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
 
-
 ## Mutation guidelines
+
 - Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`
 - Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`
 
 ## Action guidelines
+
 - Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
 - Never add `"use node";` to a file that also exports queries or mutations. Only actions can run in the Node.js runtime; queries and mutations must stay in the default Convex runtime. If you need Node.js built-ins alongside queries or mutations, put the action in a separate file.
 - `fetch()` is available in the default Convex runtime. You do NOT need `"use node";` just to use `fetch()`.
 - Never use `ctx.db` inside of an action. Actions don't have access to the database.
 - Below is an example of the syntax for an action:
+
 ```ts
 import { action } from "./_generated/server";
 
 export const exampleAction = action({
-    args: {},
-    handler: async (ctx, args) => {
-        console.log("This action does not return anything");
-        return null;
-    },
+  args: {},
+  handler: async (ctx, args) => {
+    console.log("This action does not return anything");
+    return null;
+  },
 });
 ```
 
 ## Scheduling guidelines
+
 ### Cron guidelines
+
 - Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
 - Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
 - Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
+
 ```ts
 import { cronJobs } from "convex/server";
 import { internal } from "./_generated/api";
@@ -269,14 +304,16 @@ crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
 
 export default crons;
 ```
-- You can register Convex functions within `crons.ts` just like any other file.
-- If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file.
 
+- You can register Convex functions within `crons.ts` just like any other file.
+- If a cron calls an internal function, always import the `internal` object from '\_generated/api', even if the internal function is registered in the same file.
 
 ## Testing guidelines
+
 - Use `convex-test` with `vitest` and `@edge-runtime/vm` to test Convex functions. Always install the latest versions of these packages. Configure vitest with `environment: "edge-runtime"` in `vitest.config.ts`.
 
 Test files go inside the `convex/` directory. You must pass a module map from `import.meta.glob` to `convexTest`:
+
 ```typescript
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
@@ -293,13 +330,16 @@ test("some behavior", async () => {
   expect(messages).toMatchObject([{ body: "Hi!", author: "Sarah" }]);
 });
 ```
+
 The `modules` argument is required so convex-test can discover and load function files. The `/// <reference types="vite/client" />` directive is needed for TypeScript to recognize `import.meta.glob`.
 
 ## File storage guidelines
+
 - The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
 - Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
 
 Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+
 ```
 import { query } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
@@ -321,6 +361,5 @@ export const exampleQuery = query({
     },
 });
 ```
+
 - Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.
-
-

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -125,14 +125,3 @@ export const seed = internalMutation({
     }
   },
 });
-
-// Alternatively, you can specify a prefix.
-export const migrationsWithPrefix = new Migrations(components.migrations, {
-  // Specifying the internalMutation means you don't need the type parameter.
-  // Also, if you have a custom internalMutation, you can specify it here.
-  internalMutation,
-  migrationsLocationPrefix: "example:",
-});
-
-// Allows you to run `npx convex run example:runWithPrefix '{"fn":"setDefaultValue"}'`
-export const runWithPrefix = migrationsWithPrefix.runner();

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@vitejs/plugin-react": "5.0.4",
         "chokidar-cli": "3.0.0",
         "convex": "1.35.1",
-        "convex-test": "0.0.41",
+        "convex-test": "0.0.48",
         "eslint": "9.39.1",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "7.0.1",
@@ -2943,13 +2943,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.41.tgz",
-      "integrity": "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.48.tgz",
+      "integrity": "sha512-ewAkXwNJE0TpHAfHJt38NR6ZsArqdzd4HUy9BxegKENvupYwWCVJezFfkIJoYaZThqPABEfmiChvG8KCqCTm5w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.32.0"
       }
     },
     "node_modules/convex/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@vitejs/plugin-react": "5.0.4",
     "chokidar-cli": "3.0.0",
     "convex": "1.35.1",
-    "convex-test": "0.0.41",
+    "convex-test": "0.0.48",
     "eslint": "9.39.1",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.0.1",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "convex": {
+      "source": "get-convex/agent-skills",
+      "sourceType": "github",
+      "computedHash": "613ee9955985085d0fca8f96e1fc6d7cfd204dffa203499a1d508b8def76577b"
+    },
     "convex-create-component": {
       "source": "get-convex/agent-skills",
       "sourceType": "github",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -45,8 +45,6 @@ export class Migrations<DataModel extends GenericDataModel> {
    * import { internalMutation } from "./_generated/server";
    *
    * export const migrations = new Migrations(components.migrations, { internalMutation });
-   * // the private mutation to run migrations.
-   * export const run = migrations.runner();
    *
    * export const myMigration = migrations.define({
    *  table: "users",
@@ -57,7 +55,7 @@ export class Migrations<DataModel extends GenericDataModel> {
    * ```
    * You can then run it from the CLI or dashboard:
    * ```sh
-   * npx convex run migrations:run '{"fn": "migrations:myMigration"}'
+   * npx convex run migrations:myMigration
    * ```
    * For starting a migration from code, see {@link runOne}/{@link runSerially}.
    * @param component - The migrations component. It will be on components.migrations
@@ -95,6 +93,8 @@ export class Migrations<DataModel extends GenericDataModel> {
   ) {}
 
   /**
+   * @deprecated You can now start migrations by calling them directly
+   *
    * Creates a migration runner that can be called from the CLI or dashboard.
    *
    * For starting a migration from code, see {@link runOne}/{@link runSerially}.
@@ -235,23 +235,18 @@ export class Migrations<DataModel extends GenericDataModel> {
    * You can run this manually from the CLI or dashboard:
    * ```sh
    * # Start or resume a migration. No-ops if it's already done:
-   * npx convex run migrations:run '{"fn": "migrations:foo"}'
+   * npx convex run migrations:foo
    *
    * # Restart a migration from the beginning (also resets next migrations):
-   * npx convex run migrations:run '{"fn": "migrations:foo", "reset": true }'
+   * npx convex run migrations:foo '{reset: true}'
    *
-   * # Dry run - runs one batch but doesn't schedule or commit changes.
+   * # Dry run - runs one batch but doesn't schedule or commit changes,
    * # so you can see what it would do without committing the transaction.
-   * npx convex run migrations:run '{"fn": "migrations:foo", "dryRun": true}'
-   * # or
-   * npx convex run migrations:myMigration '{"dryRun": true}'
+   * npx convex run migrations:foo '{dryRun: true}'
    *
    * # Run many migrations serially:
-   * npx convex run migrations:run '{"fn": "migrations:foo", "next": ["migrations:bar", "migrations:baz"] }'
+   * npx convex run migrations:foo '{next: ["migrations:bar", "migrations:baz"]}'
    * ```
-   *
-   * The fn is the string form of the function reference. See:
-   * https://docs.convex.dev/functions/query-functions#query-names
    *
    * See {@link runOne} and {@link runSerially} for programmatic use.
    *
@@ -298,27 +293,40 @@ export class Migrations<DataModel extends GenericDataModel> {
     )({
       args: migrationArgs,
       handler: async (ctx, args) => {
-        if (args.fn) {
-          // This is a one-off execution from the CLI or dashboard.
-          // While not the recommended appproach, it's helpful for one-offs and
-          // compatibility with the old way of running migrations.
-
-          return (await this._runInteractive(ctx, args)) as any;
-        } else if (args.next?.length) {
-          throw new Error("You can only pass next if you also provide fn");
-        } else if (
+        // Auto-detect function name for direct CLI/dashboard invocation.
+        // The component always provides cursor and dryRun when scheduling
+        // batches, so if either is missing this is a direct invocation.
+        if (
+          args.fn ||
+          args.next ||
           args.cursor === undefined ||
           args.cursor === "" ||
           args.dryRun === undefined ||
           args.batchSize === 0
         ) {
-          console.warn(
-            "Running this from the CLI or dashboard? Here's some args to use:",
-          );
-          console.warn({
-            "Dry run": '{ "dryRun": true, "reset": true }',
-            "For real": '{ "fn": "path/to/migrations:yourFnName" }',
-          });
+          if (args.cursor === "" || args.batchSize === 0) {
+            console.warn(
+              "Running this from the CLI or dashboard? Here's some args to use:",
+            );
+            console.warn({
+              "Dry run": '{ "dryRun": true, "reset": true }',
+              "For real": "{}",
+            });
+            return;
+          }
+          const metadata = await getFunctionMetadata();
+          if (args.fn && this.prefixedName(args.fn) !== metadata.name) {
+            throw new Error(
+              `Function name mismatch: expected ${metadata.name}, got ${args.fn}. Hint: you can `,
+            );
+          }
+          return (await this._runInteractive(
+            ctx,
+            args,
+            makeFunctionReference(
+              metadata.name,
+            ) as unknown as MigrationFunctionReference,
+          )) as any;
         }
 
         const numItems = args.batchSize || defaultBatchSize;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -93,8 +93,6 @@ export class Migrations<DataModel extends GenericDataModel> {
   ) {}
 
   /**
-   * @deprecated You can now start migrations by calling them directly
-   *
    * Creates a migration runner that can be called from the CLI or dashboard.
    *
    * For starting a migration from code, see {@link runOne}/{@link runSerially}.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -726,7 +726,7 @@ export async function getFunctionMetadata(): Promise<{
   name: string;
   componentPath: string;
 }> {
-  const syscalls = (global as any).Convex;
+  const syscalls = (globalThis as any).Convex;
   return JSON.parse(
     await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
   );
@@ -749,7 +749,7 @@ type TransactionMetrics = {
 
 // TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
 export async function getTransactionMetrics(): Promise<TransactionMetrics> {
-  const syscalls = (global as any).Convex;
+  const syscalls = (globalThis as any).Convex;
   return JSON.parse(
     await syscalls.asyncSyscall(
       "1.0/getTransactionMetrics",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -714,3 +714,40 @@ type ActionCtx = Pick<
   GenericActionCtx<GenericDataModel>,
   "runQuery" | "runMutation" | "storage"
 >;
+
+// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
+export async function getFunctionMetadata(): Promise<{
+  name: string;
+  componentPath: string;
+}> {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
+  );
+}
+
+type TransactionMetric = {
+  used: number;
+  remaining: number;
+};
+
+type TransactionMetrics = {
+  bytesRead: TransactionMetric;
+  bytesWritten: TransactionMetric;
+  databaseQueries: TransactionMetric;
+  documentsRead: TransactionMetric;
+  documentsWritten: TransactionMetric;
+  functionsScheduled: TransactionMetric;
+  scheduledFunctionArgsBytes: TransactionMetric;
+};
+
+// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
+export async function getTransactionMetrics(): Promise<TransactionMetrics> {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall(
+      "1.0/getTransactionMetrics",
+      JSON.stringify({}),
+    ),
+  );
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -314,8 +314,11 @@ export class Migrations<DataModel extends GenericDataModel> {
           }
           const metadata = await getFunctionMetadata();
           if (args.fn && this.prefixedName(args.fn) !== metadata.name) {
+            const componentFlag = metadata.componentPath
+              ? ` --component ${metadata.componentPath}`
+              : "";
             throw new Error(
-              `Function name mismatch: expected ${metadata.name}, got ${args.fn}. Hint: you can `,
+              `Function name mismatch: expected ${metadata.name}, got ${args.fn}. Hint: you can call it directly with \`npx convex run ${metadata.name}${componentFlag}\`.`,
             );
           }
           return (await this._runInteractive(


### PR DESCRIPTION
## Allow calling a migration directly

Enhanced migration system to support direct CLI invocation:

- Migrations can now be called directly: `npx convex run migrations:myMigration`
- Auto-detects direct invocation vs scheduled batch execution
- Maintains backward compatibility with `migrations.runner()` pattern
- Added function name validation for security
- Improved error messages and usage hints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added Convex AI guidance routing skill with documentation
  - Introduced new utilities for function metadata and transaction metrics retrieval
  - Enabled auto-detection of CLI/dashboard migration invocation

* **Documentation**
  - Updated README with revised CLI examples for migration execution

* **Refactor**
  - Simplified migration runner pattern; removed prefix-based alternatives

* **Chores**
  - Updated development dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->