### PR TITLE
pass in "oneBatchOnly" explicitly to the migration function so running from the CLI is always explicit if it wants to start /continue vs. do one batch

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -294,14 +294,7 @@ export class Migrations<DataModel extends GenericDataModel> {
         // Auto-detect function name for direct CLI/dashboard invocation.
         // The component always provides cursor and dryRun when scheduling
         // batches, so if either is missing this is a direct invocation.
-        if (
-          args.fn ||
-          args.next ||
-          args.cursor === undefined ||
-          args.cursor === "" ||
-          args.dryRun === undefined ||
-          args.batchSize === 0
-        ) {
+        if (!args.oneBatchOnly) {
           if (args.cursor === "" || args.batchSize === 0) {
             console.warn(
               "Running this from the CLI or dashboard? Here's some args to use:",

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -117,6 +117,7 @@ export const migrate = mutation({
             cursor: state.cursor,
             batchSize,
             dryRun,
+            oneBatchOnly: true,
           },
         );
         updateState(result);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -7,6 +7,7 @@ export const migrationArgs = {
   dryRun: v.optional(v.boolean()),
   next: v.optional(v.array(v.string())),
   reset: v.optional(v.boolean()),
+  oneBatchOnly: v.optional(v.boolean()),
 };
 export type MigrationArgs = ObjectType<typeof migrationArgs>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved migration execution behavior to process one batch per direct invocation, ensuring more predictable batch handling and cursor progression during migration runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->