### PR TITLE
Adapt migration batch sizing based on transaction metrics; resiliently reduce batch size on limit exceeds and OCC failures instead of failing and stopping; support multiple ranges in customRange()

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ import schema from "./_generated/schema.js";
 export const migrations = new Migrations(components.migrations, { schema });
 ```
 
-The `schema` provides type safety for migration definitions and support
-for pagination over custom indexes with
-[`customRange`](#migrating-a-subset-of-a-table-using-an-index).
-As always, database operations in migrations will abide
-by your schema definition at runtime. **Note**: if you use
+The `schema` provides type safety for migration definitions and support for
+pagination over custom indexes with
+[`customRange`](#migrating-a-subset-of-a-table-using-an-index). As always,
+database operations in migrations will abide by your schema definition at
+runtime. **Note**: if you use
 [custom functions](https://stack.convex.dev/custom-functions) to override
 `internalMutation`, see
 [below](#override-the-internalmutation-to-apply-custom-db-behavior).
@@ -163,6 +163,26 @@ export const validateRequiredField = migrations.define({
 ```
 
 Note: to use customRange, you must provide your schema to Migrations.
+
+`customRange` may also return an array of ranges. This is useful when a single
+logical migration needs to read several indexed subsets without scanning the
+whole table. The component runs each range to completion before advancing to the
+next one.
+
+```ts
+export const validateRequiredFields = migrations.define({
+  table: "myTable",
+  customRange: (query) => [
+    query.withIndex("by_requiredField", (q) =>
+      q.eq("requiredField", "<todo1>"),
+    ),
+    query.withIndex("by_requiredField", (q) =>
+      q.eq("requiredField", "<todo2>"),
+    ),
+  ],
+  migrateOne: () => ({ requiredField: "<unknown>" }),
+});
+```
 
 ## Running migrations one at a time
 
@@ -307,6 +327,11 @@ You can also pass in any valid cursor to start from. You can find valid cursors
 in the response of calls to `getStatus`. This can allow retrying a migration
 from a known good point as you iterate on the code.
 
+For a migration whose `customRange` returns multiple ranges, the cursor is
+scoped to the current range. Pass both `cursor` and `currentRangeIndex` from
+`getStatus` when resuming from a known point in any range after the first.
+Passing `reset: true` resets `currentRangeIndex` to `0`.
+
 Note: if you're starting a migration from a specific cursor from the CLI or
 dashboard, do not pass `dryRun: false` explicitly, leave it undefined.
 
@@ -367,8 +392,8 @@ npx convex deploy --cmd 'npm run build' && npx convex run convex/migrations.ts:r
 
 ### Override the internalMutation to apply custom DB behavior
 
-You can customize which `internalMutation` implementation the underly migration
-should use.
+You can customize which `internalMutation` implementation the underlying
+migration should use.
 
 This might be important if you use
 [custom functions](https://stack.convex.dev/custom-functions) to intercept
@@ -392,12 +417,74 @@ more information on usage and advanced patterns.
 
 ### Custom batch size
 
-The component will fetch your data in batches of 100, and call your function on
-each document in a batch. If you want to change the batch size, you can specify
-it. This can be useful if your documents are large, to avoid running over the
+The starting batch size comes from the migration definition's `batchSize`, then
+the `Migrations` instance's `defaultBatchSize`, and otherwise defaults to `100`.
+You can also override it for a particular run. This can be useful if your
+documents are large, to avoid running over the
 [transaction limit](https://docs.convex.dev/production/state/limits#transactions),
 or if your documents are updating frequently and you are seeing OCC conflicts
 while migrating.
+
+When you do not pass an explicit batch size for a run, the component treats that
+resolved size as the starting size and then adjusts future batches from Convex
+transaction metrics and the observed wall time of the nested migration
+mutation. After a successful batch, it estimates the largest next batch that
+would keep the highest
+transaction-limit usage at or below half of the limit and wall time near 500
+milliseconds, half of Convex's documented
+[one-second mutation execution limit](https://docs.convex.dev/production/state/limits#execution-time-and-scheduling).
+If adding one more document would be expected to cross the tightest target, the
+batch size stays unchanged; if the last batch exceeded a target, the next batch
+shrinks toward it.
+
+The wall-time measurement starts immediately before the nested migration
+mutation and stops when that call returns. It includes nested-call and database
+syscall overhead, but not the enclosing transaction's commit or top-level OCC
+retries. It is a conservative signal, not Convex's internal user-execution time.
+`getStatus` reports the dimension that caused a shrink as `limitingMetric`;
+wall-time reductions use `mutationWallTime`.
+
+Known transaction-limit failures from the nested migration are caught inside the
+controller mutation. Covered limits are bytes read, documents read, database
+queries, bytes written, documents written, scheduled-function count, and
+scheduled-function argument bytes. Scheduled continuations run through an
+internal action. If the full controller mutation instead fails at its outer
+boundary with a permanent OCC error, user-execution timeout, or cumulative
+system-operations timeout, that action can catch the real failure after the
+transaction rolls back. A recovery mutation verifies the worker generation and
+stored cursor/range before scheduling a smaller retry, so it does not advance or
+overwrite newer progress.
+
+Each recognized failure halves the smallest known failed batch size. Retries can
+go below the configured or default batch size, down to `1`. A recognized
+failure at batch size `1`, an unrecognized failure, or a failure whose attempted
+batch size is unknown stops the migration. When the controller or worker
+recovery can commit, it stores that error in status; an uncaught first-call or
+`runToCompletion` outer failure is returned to its caller instead. OCC and
+the two hard timeout reductions are reported as `optimisticConcurrencyControl`,
+`mutationUserExecutionTime`, and `mutationSystemOperationsTime`, respectively.
+The successful wall-time signal includes syscall waiting, so it already reacts
+to expensive system operations without inventing separate successful user-time
+or system-time estimates that Convex does not expose.
+
+Underfilled pages do not change the adaptive size or its known failure bound.
+This matters for migrations over multiple custom ranges: the last page in one
+range may be much smaller than requested and does not predict the cost of
+documents in the next range. Resuming a migration without an explicit
+`batchSize` also preserves its stored adaptive size.
+
+A `batchSize` in the migration definition sets that migration's starting/default
+size. Passing `batchSize` for a particular run keeps successful batches fixed at
+that size; a recognized failure may still force a smaller retry.
+
+The first direct call to a migration remains a mutation for API compatibility.
+The component therefore cannot automatically catch a top-level OCC failure or
+hard timeout from that call. Retry it with a smaller explicit `batchSize`; once
+a batch schedules a continuation, the continuation uses the action-backed
+worker. `runToCompletion` already runs at an action boundary and reduces known
+outer failures when it knows the attempted size, either from `batchSize` or
+stored migration status. When starting `runToCompletion` from an explicit
+cursor, pass `batchSize` if the first attempt also needs this recovery.
 
 ```ts
 export const clearField = migrations.define({

--- a/example/convex/example.test.ts
+++ b/example/convex/example.test.ts
@@ -91,7 +91,9 @@ describe("example", () => {
         internal.example.validateRequiredField,
       ]),
     );
-    expect(second?.name).toBe(getFunctionName(internal.example.setDefaultValue));
+    expect(second?.name).toBe(
+      getFunctionName(internal.example.setDefaultValue),
+    );
     expect(second?.state).toBe("inProgress");
     expect(second?.processed).toBe(first?.processed);
   });
@@ -151,6 +153,150 @@ describe("example", () => {
       const after = await ctx.db.query("myTable").collect();
       expect(after).toHaveLength(10);
       expect(after.every((doc) => doc.optionalField !== undefined)).toBe(true);
+    });
+  });
+
+  test("test migration over multiple custom ranges", async () => {
+    const t = initConvexTest();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("myTable", {
+        requiredField: "<todo1>",
+        unionField: 1,
+      });
+      await ctx.db.insert("myTable", {
+        requiredField: "<todo1>",
+        unionField: 2,
+      });
+      await ctx.db.insert("myTable", {
+        requiredField: "<todo2>",
+        unionField: 3,
+      });
+      await ctx.db.insert("myTable", {
+        requiredField: "keep",
+        unionField: 4,
+      });
+    });
+
+    await t.run(async (ctx) => {
+      await runToCompletion(
+        ctx,
+        components.migrations,
+        internal.example.validateRequiredFieldVariants,
+      );
+    });
+
+    await t.run(async (ctx) => {
+      const after = await ctx.db.query("myTable").collect();
+      expect(
+        after.filter((doc) => doc.requiredField === "<unknown>"),
+      ).toHaveLength(3);
+      expect(after.filter((doc) => doc.requiredField === "keep")).toHaveLength(
+        1,
+      );
+    });
+  });
+
+  test("runToCompletion resumes multi-range migration at stored range", async () => {
+    const t = initConvexTest();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("myTable", {
+        requiredField: "<todo1>",
+        unionField: 1,
+      });
+      await ctx.db.insert("myTable", {
+        requiredField: "<todo2>",
+        unionField: 2,
+      });
+    });
+
+    await t.run(async (ctx) => {
+      const fnHandle = await createFunctionHandle(
+        internal.example.validateRequiredFieldVariants,
+      );
+      const first = await ctx.runMutation(components.migrations.lib.migrate, {
+        name: getFunctionName(internal.example.validateRequiredFieldVariants),
+        fnHandle,
+        cursor: null,
+        currentRangeIndex: 0,
+        batchSize: 10,
+        dryRun: false,
+        oneBatchOnly: true,
+        adaptiveBatchSize: false,
+      });
+
+      expect(first.isDone).toBe(false);
+      expect(first.currentRangeIndex).toBe(1);
+      expect(first.processed).toBe(1);
+    });
+
+    await t.run(async (ctx) => {
+      const status = await runToCompletion(
+        ctx,
+        components.migrations,
+        internal.example.validateRequiredFieldVariants,
+      );
+
+      expect(status.isDone).toBe(true);
+      expect(status.processed).toBe(2);
+    });
+  });
+
+  test("direct invocation resumes with the stored batch size", async () => {
+    const t = initConvexTest();
+    await t.mutation(internal.example.seed, { count: 3 });
+
+    await t.run(async (ctx) => {
+      const fnHandle = await createFunctionHandle(
+        internal.example.setDefaultValue,
+      );
+      const first = await ctx.runMutation(components.migrations.lib.migrate, {
+        name: getFunctionName(internal.example.setDefaultValue),
+        fnHandle,
+        cursor: null,
+        batchSize: 1,
+        dryRun: false,
+        oneBatchOnly: true,
+        adaptiveBatchSize: false,
+      });
+
+      expect(first.isDone).toBe(false);
+      expect(first.processed).toBe(1);
+      expect(first.batchSize).toBe(1);
+    });
+
+    const resumed = await t.mutation(internal.example.setDefaultValue, {});
+
+    expect(resumed?.processed).toBe(2);
+  });
+
+  test("runToCompletion no-ops while scheduled worker is active", async () => {
+    const t = initConvexTest();
+    await t.mutation(internal.example.seed, { count: 3 });
+
+    await t.run(async (ctx) => {
+      const fnHandle = await createFunctionHandle(
+        internal.example.setDefaultValue,
+      );
+      const first = await ctx.runMutation(components.migrations.lib.migrate, {
+        name: getFunctionName(internal.example.setDefaultValue),
+        fnHandle,
+        cursor: null,
+        batchSize: 1,
+        dryRun: false,
+        adaptiveBatchSize: false,
+      });
+      expect(first.state).toBe("inProgress");
+      expect(first.processed).toBe(1);
+
+      const status = await runToCompletion(
+        ctx,
+        components.migrations,
+        internal.example.setDefaultValue,
+        { batchSize: 1 },
+      );
+
+      expect(status.state).toBe("inProgress");
+      expect(status.processed).toBe(1);
     });
   });
 });

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -39,6 +39,20 @@ export const validateRequiredField = migrations.define({
   },
 });
 
+export const validateRequiredFieldVariants = migrations.define({
+  table: "myTable",
+  batchSize: 1,
+  customRange: (query) => [
+    query.withIndex("by_requiredField", (q) =>
+      q.eq("requiredField", "<todo1>"),
+    ),
+    query.withIndex("by_requiredField", (q) =>
+      q.eq("requiredField", "<todo2>"),
+    ),
+  ],
+  migrateOne: () => ({ requiredField: "<unknown>" }),
+});
+
 // If you prefer the old-style migration definition, you can define `migration`:
 const migration = migrations.define.bind(migrations);
 // Then use it like this:

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,5 +1,10 @@
-import { describe, test, expect } from "vitest";
-import { Migrations, DEFAULT_BATCH_SIZE, isNewFormatCursor } from "./index.js";
+import { describe, expect, test, vi } from "vitest";
+import {
+  DEFAULT_BATCH_SIZE,
+  isNewFormatCursor,
+  Migrations,
+  runToCompletion,
+} from "./index.js";
 import type { ComponentApi } from "../component/_generated/component.js";
 
 describe("Migrations class", () => {
@@ -40,5 +45,56 @@ describe("isNewFormatCursor", () => {
     expect(isNewFormatCursor("")).toBe(false);
     expect(isNewFormatCursor("{}")).toBe(false); // object, not array
     expect(isNewFormatCursor("null")).toBe(false); // string "null"
+  });
+});
+
+describe("runToCompletion", () => {
+  test("does not retry a known failed size after adaptive growth", async () => {
+    const runMutation = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Function execution timed out (maximum duration: 1s)"),
+      )
+      .mockResolvedValueOnce({
+        name: "migrations:test",
+        cursor: "after-five",
+        processed: 2,
+        isDone: false,
+        state: "unknown",
+        latestStart: 0,
+        batchSize: 20,
+        currentRangeIndex: 0,
+      })
+      .mockResolvedValueOnce({
+        name: "migrations:test",
+        cursor: null,
+        processed: 12,
+        isDone: true,
+        state: "success",
+        latestStart: 0,
+        currentRangeIndex: 0,
+      });
+    const ctx = {
+      runMutation,
+    } as unknown as Parameters<typeof runToCompletion>[0];
+    const component = {
+      lib: { migrate: {} },
+    } as ComponentApi;
+
+    await runToCompletion(
+      ctx,
+      component,
+      "function://test" as Parameters<typeof runToCompletion>[2],
+      { name: "migrations:test", cursor: null, batchSize: 10 },
+    );
+
+    expect(runMutation.mock.calls.map(([, args]) => args.batchSize)).toEqual([
+      10, 5, 5,
+    ]);
+    expect(runMutation.mock.calls.map(([, args]) => args.cursor)).toEqual([
+      null,
+      null,
+      undefined,
+    ]);
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -24,6 +24,9 @@ import {
   type TableNamesInDataModel,
 } from "convex/server";
 import {
+  MIGRATION_BATCH_FAILURE,
+  getMigrationDryRunResult,
+  getMigrationDryRunStatus,
   type MigrationArgs,
   migrationArgs,
   type MigrationResult,
@@ -33,6 +36,13 @@ export type { MigrationArgs, MigrationResult, MigrationStatus };
 
 import { ConvexError, type GenericId } from "convex/values";
 import type { ComponentApi } from "../component/_generated/component.js";
+import {
+  chooseBatchSizeAfterLimitFailure,
+  getTransactionLimitMetric,
+  looksLikeExecutionTimeout,
+  looksLikeOccError,
+  looksLikeSystemOperationsTimeout,
+} from "../component/batchSize.js";
 import type { MigrationFunctionHandle } from "../component/lib.js";
 import { logStatusAndInstructions } from "./log.js";
 
@@ -222,6 +232,7 @@ export class Migrations<
     args: MigrationArgs,
     fnRef?: MigrationFunctionReference,
     next?: { name: string; fnHandle: string }[],
+    initialBatchSize?: number,
   ) {
     const name = args.fn ? this.prefixedName(args.fn) : getFunctionName(fnRef!);
     async function makeFn(fn: string) {
@@ -259,7 +270,7 @@ export class Migrations<
         ...(next ?? []).map((n) => n.name),
       ]);
       if (inProgress) {
-        const { componentPath } = await getFunctionMetadata();
+        const { componentPath } = await ctx.meta.getFunctionMetadata();
         return logStatusAndInstructions(
           inProgress.name,
           inProgress,
@@ -270,30 +281,39 @@ export class Migrations<
     }
     // Handle reset option: reset sets cursor to null for all migrations
     const cursor = args.reset ? null : args.cursor;
+    // Missing position fields mean "resume the component's stored position".
+    // Explicit cursor/reset starts from range 0 unless a caller intentionally
+    // supplied another range index.
+    const currentRangeIndex =
+      args.reset || args.cursor !== undefined
+        ? (args.currentRangeIndex ?? 0)
+        : args.currentRangeIndex;
     let status: MigrationStatus;
     try {
       status = await ctx.runMutation(this.component.lib.migrate, {
         name,
         fnHandle,
-        cursor,
+        ...(cursor !== undefined ? { cursor } : {}),
+        ...(currentRangeIndex !== undefined ? { currentRangeIndex } : {}),
         batchSize: args.batchSize,
+        initialBatchSize,
         next,
         dryRun: args.dryRun ?? false,
         reset: args.reset,
+        adaptiveBatchSize: args.batchSize === undefined,
       });
     } catch (e) {
-      if (
-        args.dryRun &&
-        e instanceof ConvexError &&
-        e.data.kind === "DRY RUN"
-      ) {
-        status = e.data.status;
+      const dryRunStatus = args.dryRun
+        ? getMigrationDryRunStatus(e)
+        : undefined;
+      if (dryRunStatus !== undefined) {
+        status = dryRunStatus;
       } else {
         throw e;
       }
     }
 
-    const { componentPath } = await getFunctionMetadata();
+    const { componentPath } = await ctx.meta.getFunctionMetadata();
     return logStatusAndInstructions(name, status, args, componentPath);
   }
 
@@ -336,6 +356,8 @@ export class Migrations<
    * @param batchSize - The number of documents to process in a batch.
    *   If not set, defaults to the value passed to makeMigration,
    *   or {@link DEFAULT_BATCH_SIZE}. Overriden by arg at runtime if supplied.
+   * @param customRange - The indexed subset to migrate. Return an array to run
+   *   multiple indexed ranges in sequence.
    * @param parallelize - If true, each migration batch will be run in parallel.
    * @returns An internal mutation that runs the migration.
    */
@@ -356,7 +378,9 @@ export class Migrations<
       | Promise<Partial<DocumentByName<DataModel, TableName>> | void>;
     customRange?: (
       q: QueryInitializer<NamedTableInfo<DataModel, TableName>>,
-    ) => OrderedQuery<NamedTableInfo<DataModel, TableName>>;
+    ) =>
+      | OrderedQuery<NamedTableInfo<DataModel, TableName>>
+      | readonly OrderedQuery<NamedTableInfo<DataModel, TableName>>[];
     batchSize?: number;
     parallelize?: boolean;
   }) {
@@ -388,7 +412,7 @@ export class Migrations<
             });
             return;
           }
-          const metadata = await getFunctionMetadata();
+          const metadata = await ctx.meta.getFunctionMetadata();
           if (args.fn && this.prefixedName(args.fn) !== metadata.name) {
             const componentFlag = metadata.componentPath
               ? ` --component ${metadata.componentPath}`
@@ -403,146 +427,198 @@ export class Migrations<
             makeFunctionReference(
               metadata.name,
             ) as unknown as MigrationFunctionReference,
+            undefined,
+            defaultBatchSize,
           )) as any;
         }
 
-        const numItems = args.batchSize || defaultBatchSize;
-        if (args.cursor === undefined || args.cursor === "") {
-          if (args.dryRun === undefined) {
-            console.warn(
-              "No cursor or dryRun specified - doing a dry run on the next batch.",
-            );
-            args.cursor = null;
-            args.dryRun = true;
-          } else if (args.dryRun) {
-            console.warn("Setting cursor to null for dry run");
-            args.cursor = null;
-          } else {
-            throw new Error(`Cursor must be specified for a one-off execution.
+        const numItems = args.batchSize ?? defaultBatchSize;
+        if (!Number.isInteger(numItems)) {
+          throw new Error("Batch size must be an integer");
+        }
+        if (numItems <= 0) {
+          throw new Error("Batch size must be greater than 0");
+        }
+        try {
+          if (args.cursor === undefined || args.cursor === "") {
+            if (args.dryRun === undefined) {
+              console.warn(
+                "No cursor or dryRun specified - doing a dry run on the next batch.",
+              );
+              args.cursor = null;
+              args.dryRun = true;
+            } else if (args.dryRun) {
+              console.warn("Setting cursor to null for dry run");
+              args.cursor = null;
+            } else {
+              throw new Error(`Cursor must be specified for a one-off execution.
               Use null to start from the beginning.
               Use the value in the migrations database to pick up from where it left off.`);
+            }
           }
-        }
 
-        // Determine which pagination method to use
-        const cursorIsOldFormat =
-          args.cursor !== null &&
-          args.cursor !== undefined &&
-          !isNewFormatCursor(args.cursor);
+          // Determine which pagination method to use
+          const cursorIsOldFormat =
+            args.cursor !== null &&
+            args.cursor !== undefined &&
+            !isNewFormatCursor(args.cursor);
 
-        // Use paginator when cursor is compatible.
-        // Falls back to built-in db.query for old-format cursors from
-        // in-progress migrations that started before the paginator was used.
-        const useNewPaginator = !cursorIsOldFormat;
-        if (useNewPaginator && customRange && !this.options?.schema) {
-          throw new Error(
-            `You must provide your schema to use a custom range.`,
-          );
-        }
-        const paginatorSchema = (this.options?.schema ??
-          defineSchema({ [table]: defineTable({}) })) as SchemaDefinition<
-          Record<TableName, TableDefinition>,
-          true
-        >;
+          // Use paginator when cursor is compatible.
+          // Falls back to built-in db.query for old-format cursors from
+          // in-progress migrations that started before the paginator was used.
+          const useNewPaginator = !cursorIsOldFormat;
+          if (useNewPaginator && customRange && !this.options?.schema) {
+            throw new Error(
+              `You must provide your schema to use a custom range.`,
+            );
+          }
+          const paginatorSchema = (this.options?.schema ??
+            defineSchema({ [table]: defineTable({}) })) as SchemaDefinition<
+            Record<TableName, TableDefinition>,
+            true
+          >;
 
-        // Build the query using either paginator or built-in db.query
-        // Both implement compatible QueryInitializer interfaces
-        const q = useNewPaginator
-          ? (paginator(ctx.db as any, paginatorSchema).query(
-              table,
-            ) as unknown as QueryInitializer<
-              NamedTableInfo<DataModel, TableName>
-            >)
-          : ctx.db.query(table);
-        const range = customRange ? customRange(q) : q;
-        let continueCursor: string;
-        let page: DocumentByName<DataModel, TableName>[];
-        let isDone: boolean;
-        try {
-          ({ continueCursor, page, isDone } = await range.paginate({
-            cursor: args.cursor,
-            numItems,
-          }));
-        } catch (e) {
-          console.error(
-            "Error paginating. This can happen if the migration " +
-              "was initially run on a different table, different custom range, " +
-              "or you upgraded convex-helpers with in-progress migrations. " +
-              "This creates an invalid pagination cursor. " +
-              "Run all migrations to completion on the old cursor, or re-run " +
-              "them explicitly with the cursor set to null. " +
-              "If the problem persists, contact support@convex.dev",
-          );
-          throw e;
-        }
-        async function doOne(doc: DocumentByName<DataModel, TableName>) {
+          // Build the query using either paginator or built-in db.query
+          // Both implement compatible QueryInitializer interfaces
+          const q = useNewPaginator
+            ? (paginator(ctx.db as any, paginatorSchema).query(
+                table,
+              ) as unknown as QueryInitializer<
+                NamedTableInfo<DataModel, TableName>
+              >)
+            : ctx.db.query(table);
+          const range = customRange ? customRange(q) : q;
+          const ranges = Array.isArray(range) ? range : [range];
+          if (ranges.length === 0) {
+            throw new Error("Custom range list must not be empty");
+          }
+          const currentRangeIndex = args.currentRangeIndex ?? 0;
+          if (!Number.isInteger(currentRangeIndex)) {
+            throw new Error("Current range index must be an integer");
+          }
+          if (currentRangeIndex < 0 || currentRangeIndex >= ranges.length) {
+            throw new Error(
+              "Current range index is outside the custom range list",
+            );
+          }
+          const selectedRange = ranges[currentRangeIndex]!;
+          let continueCursor: string;
+          let page: DocumentByName<DataModel, TableName>[];
+          let isDone: boolean;
           try {
-            const next = await migrateOne(
-              ctx,
-              doc as { _id: GenericId<TableName> },
+            ({ continueCursor, page, isDone } = await selectedRange.paginate({
+              cursor: args.cursor,
+              numItems,
+            }));
+          } catch (e) {
+            console.error(
+              "Error paginating. This can happen if the migration " +
+                "was initially run on a different table, different custom range, " +
+                "or you upgraded convex-helpers with in-progress migrations. " +
+                "This creates an invalid pagination cursor. " +
+                "Run all migrations to completion on the old cursor, or re-run " +
+                "them explicitly with the cursor set to null. " +
+                "If the problem persists, contact support@convex.dev",
             );
-            if (next && Object.keys(next).length > 0) {
-              await ctx.db.patch(table, doc._id as GenericId<TableName>, next);
-            }
-          } catch (error) {
-            console.error(`Document failed: ${doc._id}`);
-            throw error;
+            throw e;
           }
-        }
-        if (parallelize) {
-          await Promise.all(page.map(doOne));
-        } else {
-          for (const doc of page) {
-            await doOne(doc);
-          }
-        }
-        const result = {
-          continueCursor,
-          isDone,
-          processed: page.length,
-        };
-        if (args.dryRun) {
-          // Throwing an error rolls back the transaction
-          let anyChanges = false;
-          let printedChanges = 0;
-          for (const before of page) {
-            const after = await ctx.db.get(
-              table,
-              before._id as GenericId<TableName>,
-            );
-            if (JSON.stringify(after) !== JSON.stringify(before)) {
-              anyChanges = true;
-              printedChanges++;
-              if (printedChanges > 10) {
-                console.debug(
-                  "DRY RUN: More than 10 changes were found in the first page. Skipping the rest.",
+          async function doOne(doc: DocumentByName<DataModel, TableName>) {
+            try {
+              const next = await migrateOne(
+                ctx,
+                doc as { _id: GenericId<TableName> },
+              );
+              if (next && Object.keys(next).length > 0) {
+                await ctx.db.patch(
+                  table,
+                  doc._id as GenericId<TableName>,
+                  next,
                 );
-                break;
               }
-              console.debug("DRY RUN: Example change", {
-                before,
-                after,
-              });
+            } catch (error) {
+              console.error(`Document failed: ${doc._id}`);
+              throw error;
             }
           }
-          if (!anyChanges) {
-            console.debug(
-              "DRY RUN: No changes were found in the first page. " +
-                `Try {"dryRun": true, "cursor": "${continueCursor}"}`,
-            );
+          if (parallelize) {
+            await Promise.all(page.map(doOne));
+          } else {
+            for (const doc of page) {
+              await doOne(doc);
+            }
+          }
+          const metrics = await ctx.meta.getTransactionMetrics();
+          const resultCurrentRangeIndex = isDone
+            ? currentRangeIndex + 1
+            : currentRangeIndex;
+          const migrationIsDone = resultCurrentRangeIndex >= ranges.length;
+          // When one range finishes but later ranges remain, reset the cursor
+          // for the next range and advance currentRangeIndex. A non-done page
+          // must keep its cursor and current range.
+          const resultCursor =
+            isDone && !migrationIsDone ? null : continueCursor;
+          const result = {
+            continueCursor: resultCursor,
+            isDone: migrationIsDone,
+            processed: page.length,
+            currentRangeIndex: migrationIsDone
+              ? currentRangeIndex
+              : resultCurrentRangeIndex,
+            batchSize: numItems,
+            metrics,
+          };
+          if (args.dryRun) {
+            // Throwing an error rolls back the transaction
+            let anyChanges = false;
+            let printedChanges = 0;
+            for (const before of page) {
+              const after = await ctx.db.get(
+                table,
+                before._id as GenericId<TableName>,
+              );
+              if (JSON.stringify(after) !== JSON.stringify(before)) {
+                anyChanges = true;
+                printedChanges++;
+                if (printedChanges > 10) {
+                  console.debug(
+                    "DRY RUN: More than 10 changes were found in the first page. Skipping the rest.",
+                  );
+                  break;
+                }
+                console.debug("DRY RUN: Example change", {
+                  before,
+                  after,
+                });
+              }
+            }
+            if (!anyChanges) {
+              console.debug(
+                "DRY RUN: No changes were found in the first page. " +
+                  `Try {"dryRun": true, "cursor": "${continueCursor}"}`,
+              );
+            }
+            throw new ConvexError({
+              kind: "DRY RUN",
+              result,
+            });
+          }
+          if (args.dryRun === undefined) {
+            // We are running it in a one-off mode.
+            // The component will always provide dryRun.
+            // A bit of a hack / implicit, but non-critical logging.
+            console.debug(`Next cursor: ${continueCursor}`);
+          }
+          return result;
+        } catch (e) {
+          if (args.dryRun && getMigrationDryRunResult(e) !== undefined) {
+            throw e;
           }
           throw new ConvexError({
-            kind: "DRY RUN",
-            result,
+            kind: MIGRATION_BATCH_FAILURE,
+            batchSize: numItems,
+            message: e instanceof Error ? e.message : String(e),
           });
         }
-        if (args.dryRun === undefined) {
-          // We are running it in a one-off mode.
-          // The component will always provide dryRun.
-          // A bit of a hack / implicit, but non-critical logging.
-          console.debug(`Next cursor: ${continueCursor}`);
-        }
-        return result;
       },
     }) satisfies RegisteredMutation<
       "internal",
@@ -580,6 +656,8 @@ export class Migrations<
    * @param opts.cursor The cursor to start from.
    *   null: start from the beginning.
    *   undefined: start or resume from where it failed. If done, it won't restart.
+   * @param opts.currentRangeIndex The customRange array position to use with
+   *   opts.cursor for multi-range migrations. Defaults to 0 when opts.cursor is set.
    * @param opts.reset If true, restarts the migration from the beginning.
    * @param opts.batchSize The number of documents to process in a batch.
    * @param opts.dryRun If true, it will run a batch and then throw an error.
@@ -590,6 +668,7 @@ export class Migrations<
     fnRef: MigrationFunctionReference,
     opts?: {
       cursor?: string | null;
+      currentRangeIndex?: number;
       batchSize?: number;
       dryRun?: boolean;
       reset?: boolean;
@@ -602,13 +681,20 @@ export class Migrations<
       const inProgress = await this.anyInProgress(ctx, [name]);
       if (inProgress) return inProgress;
     }
+    const cursor = opts?.reset ? null : opts?.cursor;
+    const currentRangeIndex =
+      opts?.reset || opts?.cursor !== undefined
+        ? (opts?.currentRangeIndex ?? 0)
+        : opts?.currentRangeIndex;
     return ctx.runMutation(this.component.lib.migrate, {
       name,
       fnHandle: await createFunctionHandle(fnRef),
-      cursor: opts?.reset ? null : opts?.cursor,
+      ...(cursor !== undefined ? { cursor } : {}),
+      ...(currentRangeIndex !== undefined ? { currentRangeIndex } : {}),
       batchSize: opts?.batchSize,
       dryRun: opts?.dryRun ?? false,
       reset: opts?.reset,
+      adaptiveBatchSize: opts?.batchSize === undefined,
     });
   }
 
@@ -673,6 +759,7 @@ export class Migrations<
       fnHandle: await createFunctionHandle(fnRef),
       next,
       dryRun: false,
+      adaptiveBatchSize: true,
     });
   }
 
@@ -761,6 +848,11 @@ export type MigrationFunctionReference = FunctionReference<
  * ```
  *
  * If it's already in progress, it will no-op.
+ * Transaction-limit, user-execution-timeout, cumulative
+ * system-operations-timeout, and permanent OCC failures from the component
+ * mutation are retried with a smaller batch when the attempted batch size is
+ * known. Pass `batchSize` when starting from an explicit cursor so the first
+ * failed attempt can be reduced.
  * If you run a migration that had previously failed which was part of a series,
  * it will not resume the series.
  * To resume a series, call the series again: {@link Migrations.runSerially}.
@@ -791,6 +883,11 @@ export async function runToCompletion(
      */
     cursor?: string | null;
     /**
+     * The customRange array position to use with cursor for multi-range
+     * migrations. Defaults to 0 when cursor is set.
+     */
+    currentRangeIndex?: number;
+    /**
      * The number of documents to process in a batch.
      * Overrides the migrations's configured batch size.
      */
@@ -806,33 +903,104 @@ export async function runToCompletion(
   const {
     name = getFunctionName(fnRef),
     batchSize,
+    currentRangeIndex: initialCurrentRangeIndex,
     dryRun = false,
   } = opts ?? {};
+  let activeBatchSize = batchSize;
+  let lastFailedBatchSize: number | undefined;
+  let hasCommittedControllerCall = false;
+  let currentRangeIndex: number | undefined =
+    initialCurrentRangeIndex ?? (opts?.cursor !== undefined ? 0 : undefined);
   const address = getFunctionAddress(fnRef);
   const fnHandle =
     address.functionHandle ?? (await createFunctionHandle(fnRef));
-  while (true) {
-    const status = await ctx.runMutation(component.lib.migrate, {
-      name,
-      fnHandle,
-      cursor,
-      batchSize,
-      dryRun,
-      oneBatchOnly: true,
+  if (opts?.cursor === undefined) {
+    const [storedStatus] = await ctx.runQuery(component.lib.getStatus, {
+      names: [name],
     });
+    activeBatchSize ??= storedStatus?.batchSize;
+  }
+  while (true) {
+    const previousCursor = cursor;
+    const previousCurrentRangeIndex = currentRangeIndex;
+    const previousBatchSize = activeBatchSize;
+    // Explicit position fields choose the initial start point. Once that call
+    // commits, omission resumes the component's stored cursor and range.
+    let status: MigrationStatus;
+    try {
+      status = await ctx.runMutation(component.lib.migrate, {
+        name,
+        fnHandle,
+        ...(!hasCommittedControllerCall && cursor !== undefined
+          ? { cursor }
+          : {}),
+        ...(!hasCommittedControllerCall && currentRangeIndex !== undefined
+          ? { currentRangeIndex }
+          : {}),
+        ...(activeBatchSize !== undefined
+          ? { batchSize: activeBatchSize }
+          : {}),
+        dryRun,
+        oneBatchOnly: true,
+        adaptiveBatchSize: batchSize === undefined,
+      });
+    } catch (error) {
+      const retryable =
+        getTransactionLimitMetric(error) !== undefined ||
+        looksLikeSystemOperationsTimeout(error) ||
+        looksLikeExecutionTimeout(error) ||
+        looksLikeOccError(error);
+      if (dryRun || !retryable || activeBatchSize === undefined) {
+        throw error;
+      }
+      if (activeBatchSize <= 1) {
+        throw error;
+      }
+      lastFailedBatchSize = activeBatchSize;
+      activeBatchSize = chooseBatchSizeAfterLimitFailure({
+        batchSize: activeBatchSize,
+      });
+      continue;
+    }
+    // An explicit cursor is a start instruction, not an ownership token. Once
+    // it commits, resume stored state so another operator cannot advance the
+    // migration and then be rewound by this action's stale cursor.
+    hasCommittedControllerCall = true;
     if (status.isDone) {
       return status;
     }
     if (status.error) {
       throw new Error(status.error);
     }
-    if (!status.cursor || status.cursor === cursor) {
+    // Another scheduled worker owns progress now; running another one-batch
+    // mutation here would race it, so this helper preserves migrate's no-op.
+    if (status.state === "inProgress") {
+      return status;
+    }
+    cursor = status.cursor;
+    currentRangeIndex = status.currentRangeIndex ?? currentRangeIndex;
+    const proposedBatchSize = status.batchSize ?? activeBatchSize;
+    if (
+      proposedBatchSize !== undefined &&
+      lastFailedBatchSize !== undefined &&
+      proposedBatchSize >= lastFailedBatchSize
+    ) {
+      activeBatchSize = chooseBatchSizeAfterLimitFailure({
+        batchSize: lastFailedBatchSize,
+      });
+    } else {
+      activeBatchSize = proposedBatchSize;
+    }
+    if (
+      status.cursor === previousCursor &&
+      currentRangeIndex === previousCurrentRangeIndex &&
+      activeBatchSize === previousBatchSize
+    ) {
       throw new Error(
         "Invariant violation: Migration did not make progress." +
           `\nStatus: ${JSON.stringify(status)}`,
       );
     }
-    cursor = status.cursor;
   }
 }
 
@@ -857,46 +1025,9 @@ export function isNewFormatCursor(cursor: string | null): boolean {
 type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
 type MutationCtx = Pick<
   GenericMutationCtx<GenericDataModel>,
-  "runQuery" | "runMutation" | "meta"
+  "meta" | "runQuery" | "runMutation"
 >;
 type ActionCtx = Pick<
   GenericActionCtx<GenericDataModel>,
-  "runQuery" | "runMutation" | "storage" | "meta"
+  "meta" | "runQuery" | "runMutation" | "storage"
 >;
-
-// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
-export async function getFunctionMetadata(): Promise<{
-  name: string;
-  componentPath: string;
-}> {
-  const syscalls = (globalThis as any).Convex;
-  return JSON.parse(
-    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
-  );
-}
-
-type TransactionMetric = {
-  used: number;
-  remaining: number;
-};
-
-type TransactionMetrics = {
-  bytesRead: TransactionMetric;
-  bytesWritten: TransactionMetric;
-  databaseQueries: TransactionMetric;
-  documentsRead: TransactionMetric;
-  documentsWritten: TransactionMetric;
-  functionsScheduled: TransactionMetric;
-  scheduledFunctionArgsBytes: TransactionMetric;
-};
-
-// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
-export async function getTransactionMetrics(): Promise<TransactionMetrics> {
-  const syscalls = (globalThis as any).Convex;
-  return JSON.parse(
-    await syscalls.asyncSyscall(
-      "1.0/getTransactionMetrics",
-      JSON.stringify({}),
-    ),
-  );
-}

--- a/src/client/log.ts
+++ b/src/client/log.ts
@@ -42,6 +42,9 @@ export function logStatusAndInstructions(
     output["lastFinished"] = new Date(status.latestEnd).toISOString();
   }
   output["processed"] = status.processed;
+  if (status.limitingMetric) {
+    output["limitingMetric"] = status.limitingMetric;
+  }
   if (status.next?.length) {
     if (status.isDone) {
       output["nowUp"] = status.next;

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as batchSize from "../batchSize.js";
 import type * as lib from "../lib.js";
 
 import type {
@@ -18,6 +19,7 @@ import type {
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
+  batchSize: typeof batchSize;
   lib: typeof lib;
 }> = anyApi as any;
 

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -30,11 +30,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { name: string },
         {
           batchSize?: number;
+          currentRangeIndex: number;
           cursor?: string | null;
           error?: string;
           isDone: boolean;
           latestEnd?: number;
           latestStart: number;
+          limitingMetric?: string;
           name: string;
           next?: Array<string>;
           processed: number;
@@ -48,11 +50,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { sinceTs?: number },
         Array<{
           batchSize?: number;
+          currentRangeIndex: number;
           cursor?: string | null;
           error?: string;
           isDone: boolean;
           latestEnd?: number;
           latestStart: number;
+          limitingMetric?: string;
           name: string;
           next?: Array<string>;
           processed: number;
@@ -73,11 +77,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { limit?: number; names?: Array<string> },
         Array<{
           batchSize?: number;
+          currentRangeIndex: number;
           cursor?: string | null;
           error?: string;
           isDone: boolean;
           latestEnd?: number;
           latestStart: number;
+          limitingMetric?: string;
           name: string;
           next?: Array<string>;
           processed: number;
@@ -89,22 +95,28 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          adaptiveBatchSize?: boolean;
           batchSize?: number;
+          currentRangeIndex?: number;
           cursor?: string | null;
           dryRun: boolean;
           fnHandle: string;
+          initialBatchSize?: number;
           name: string;
           next?: Array<{ fnHandle: string; name: string }>;
           oneBatchOnly?: boolean;
           reset?: boolean;
+          workerGeneration?: number;
         },
         {
           batchSize?: number;
+          currentRangeIndex: number;
           cursor?: string | null;
           error?: string;
           isDone: boolean;
           latestEnd?: number;
           latestStart: number;
+          limitingMetric?: string;
           name: string;
           next?: Array<string>;
           processed: number;

--- a/src/component/batchSize.test.ts
+++ b/src/component/batchSize.test.ts
@@ -1,0 +1,220 @@
+import type { TransactionMetrics } from "convex/server";
+import { describe, expect, test } from "vitest";
+import {
+  chooseBatchSizeAfterLimitFailure,
+  chooseBatchSizeAfterSuccess,
+  getTransactionLimitMetric,
+  looksLikeExecutionTimeout,
+  looksLikeOccError,
+  looksLikeSystemOperationsTimeout,
+} from "./batchSize.js";
+
+describe("batch-size policy", () => {
+  test("reduces failed batch size without exact failure metrics", () => {
+    expect(chooseBatchSizeAfterLimitFailure({ batchSize: 50 })).toBe(25);
+    expect(chooseBatchSizeAfterLimitFailure({ batchSize: 1 })).toBe(1);
+  });
+
+  test("recognizes source-backed transaction-limit messages", () => {
+    expect(getTransactionLimitMetric(new Error("TooManyDocumentsRead"))).toBe(
+      "documentsRead",
+    );
+    expect(
+      getTransactionLimitMetric(
+        new Error("Uncaught Error: TooManyDocumentsRead"),
+      ),
+    ).toBe("documentsRead");
+    expect(
+      getTransactionLimitMetric(
+        new Error(
+          "Too many documents read in a single function execution (limit: 16384).",
+        ),
+      ),
+    ).toBe("documentsRead");
+  });
+
+  test("recognizes outer mutation OCC and time-limit messages", () => {
+    expect(
+      looksLikeOccError(new Error("OptimisticConcurrencyControlFailure")),
+    ).toBe(true);
+    expect(
+      looksLikeOccError(
+        new Error(
+          "Data read or written in this mutation changed while it was being run. " +
+            "Consider reducing the amount of data read by using indexed queries.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeOccError(
+        new Error(
+          "Documents read from or written to table users changed while this " +
+            "mutation was being run and on every subsequent retry.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeExecutionTimeout(
+        new Error("Function execution timed out (maximum duration: 1s)"),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeExecutionTimeout(
+        new Error(
+          "Uncaught Error: Function execution timed out (maximum duration: 750ms)",
+        ),
+      ),
+    ).toBe(true);
+    expect(looksLikeExecutionTimeout(new Error("Request timed out"))).toBe(
+      false,
+    );
+    expect(looksLikeExecutionTimeout(new Error("SystemTimeoutError"))).toBe(
+      false,
+    );
+    expect(
+      looksLikeSystemOperationsTimeout(new Error("SystemTimeoutError")),
+    ).toBe(true);
+    expect(
+      looksLikeSystemOperationsTimeout(
+        new Error("Hit maximum total syscall duration (maximum duration: 15s)"),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeSystemOperationsTimeout(
+        new Error(
+          "Your request timed out performing too many system operations.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeSystemOperationsTimeout(new Error("Request timed out")),
+    ).toBe(false);
+  });
+
+  test("grows successful batch conservatively when usage is low", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0.25),
+        durationMs: 100,
+      }).batchSize,
+    ).toBe(100);
+  });
+
+  test("skips non-finite transaction metrics", () => {
+    const metrics = metricsWithRatio(0.25);
+    metrics.bytesRead = { used: Number.NaN, remaining: 1 };
+
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics,
+        durationMs: 100,
+      }).batchSize,
+    ).toBe(100);
+  });
+
+  test("keeps growth below known failed batch size", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0.25),
+        durationMs: 100,
+        lastFailedBatchSize: 90,
+      }).batchSize,
+    ).toBe(70);
+  });
+
+  test("ignores stale failed batch size at or below successful batch size", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0.25),
+        durationMs: 100,
+        lastFailedBatchSize: 50,
+      }).batchSize,
+    ).toBe(100);
+  });
+
+  test("does not grow when one more document would exceed the target", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0.491),
+        durationMs: 100,
+      }).batchSize,
+    ).toBe(50);
+  });
+
+  test("grows when one more document stays within the target", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0.49),
+        durationMs: 100,
+      }).batchSize,
+    ).toBe(51);
+  });
+
+  test("grows by one when transaction usage is zero", () => {
+    expect(
+      chooseBatchSizeAfterSuccess({
+        batchSize: 50,
+        metrics: metricsWithRatio(0),
+        durationMs: 0,
+      }).batchSize,
+    ).toBe(51);
+  });
+
+  test("shrinks successful batch on the tightest metric returned at runtime", () => {
+    const metrics = metricsWithRatio(0.25);
+    Object.assign(metrics, {
+      vectorIndexReads: {
+        used: 0.9,
+        remaining: 0.1,
+      },
+    });
+
+    const result = chooseBatchSizeAfterSuccess({
+      batchSize: 50,
+      metrics,
+      durationMs: 100,
+    });
+
+    expect(result.batchSize).toBe(27);
+    expect(result.limitingMetric).toBe("vectorIndexReads");
+  });
+
+  test.each([
+    { batchSize: 50, durationMs: 900, expected: 27 },
+    { batchSize: 100, durationMs: 3_000, expected: 16 },
+  ])(
+    "shrinks batch size $batchSize after $durationMs ms observed wall time",
+    ({ batchSize, durationMs, expected }) => {
+      const result = chooseBatchSizeAfterSuccess({
+        batchSize,
+        metrics: metricsWithRatio(0.25),
+        durationMs,
+      });
+
+      expect(result.batchSize).toBe(expected);
+      expect(result.limitingMetric).toBe("mutationWallTime");
+    },
+  );
+});
+
+function metricsWithRatio(ratio: number): TransactionMetrics {
+  const metric = {
+    used: ratio,
+    remaining: 1 - ratio,
+  };
+  return {
+    bytesRead: metric,
+    bytesWritten: metric,
+    databaseQueries: metric,
+    documentsRead: metric,
+    documentsWritten: metric,
+    functionsScheduled: metric,
+    scheduledFunctionArgsBytes: metric,
+  };
+}

--- a/src/component/batchSize.ts
+++ b/src/component/batchSize.ts
@@ -1,0 +1,244 @@
+import { type TransactionMetrics } from "convex/server";
+
+const TARGET_USED_RATIO = 0.5;
+const DOCUMENTED_MUTATION_EXECUTION_LIMIT_MS = 1_000;
+export const MUTATION_WALL_TIME_METRIC = "mutationWallTime";
+export const MUTATION_USER_EXECUTION_TIME_METRIC = "mutationUserExecutionTime";
+export const MUTATION_SYSTEM_OPERATIONS_TIME_METRIC =
+  "mutationSystemOperationsTime";
+export const OCC_LIMITING_METRIC = "optimisticConcurrencyControl";
+
+// Successful batches use the returned TransactionMetrics object generically.
+// Failed child mutations can abort before metrics are returned to the component
+// runner, so these source-backed short and user-facing messages are the
+// fallback for classifying batch-size-reducible transaction-limit failures.
+//
+// Backend sources:
+// - Read document, byte, and index-range limits:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/database/src/reads.rs#L537-L582
+// - Write document and byte limits:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/database/src/writes.rs#L287-L301
+// - Scheduled function count and total argument-size limits:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/model/src/scheduled_jobs/mod.rs#L176-L192
+// - System-operation timeout surfaces:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/isolate/src/termination.rs#L130-L151
+// - User-execution timeout surface:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/isolate/src/termination.rs#L221-L223
+//
+// Current Convex transaction-limit dimensions:
+// - Backend limit warnings enumerate the same transaction dimensions as the
+//   TransactionMetrics object returned from successful queries/mutations:
+//   https://github.com/get-convex/convex-backend/blob/e6b2110477ac23cc988320e299c7773211a27ab1/crates/isolate/src/environment/udf/mod.rs#L875-L944
+// - convex-js documents the same TransactionMetrics fields:
+//   https://github.com/get-convex/convex-js/blob/f57c39da88fd0c93bc2d7b7eeb924c1c58f91eea/src/server/meta.ts#L21-L29
+// - `getTransactionMetrics()` is query/mutation metadata:
+//   https://github.com/get-convex/convex-js/blob/f57c39da88fd0c93bc2d7b7eeb924c1c58f91eea/src/server/meta.ts#L124-L126
+const TRANSACTION_LIMIT_ERRORS_BY_METRIC = {
+  documentsRead: [
+    "TooManyDocumentsRead",
+    "Too many documents read in a single function execution",
+  ],
+  bytesRead: [
+    "TooManyBytesRead",
+    "Too many bytes read in a single function execution",
+  ],
+  databaseQueries: [
+    "TooManyReads",
+    "Too many reads in a single function execution",
+  ],
+  // TooManyWrites also identifies the deployment-wide write-throughput limiter.
+  documentsWritten: ["Too many writes in a single function execution"],
+  bytesWritten: [
+    "TooManyBytesWritten",
+    "Too many bytes written in a single function execution",
+  ],
+  functionsScheduled: [
+    "TooManyFunctionsScheduled",
+    "Too many functions scheduled by this mutation",
+  ],
+  scheduledFunctionArgsBytes: [
+    "ScheduledFunctionsArgumentsTooLarge",
+    "Too large total size of the arguments of scheduled functions from this mutation",
+  ],
+} as const;
+type KnownTransactionMetricName =
+  keyof typeof TRANSACTION_LIMIT_ERRORS_BY_METRIC;
+const knownTransactionMetricNames = Object.keys(
+  TRANSACTION_LIMIT_ERRORS_BY_METRIC,
+) as KnownTransactionMetricName[];
+
+// An action catches the user-facing Error.message from runMutation, not the
+// backend-only short code. User-table and system-table OCCs use different
+// messages, so recognize both; keep the short code for other JS boundaries.
+const OCC_ERROR_SHORT_MESSAGE = "OptimisticConcurrencyControlFailure";
+const OCC_ERROR_USER_MESSAGE_PARTS = [
+  "Documents read from or written to",
+  "changed while this mutation was being run and on every subsequent retry",
+] as const;
+const SYSTEM_OCC_ERROR_USER_MESSAGE =
+  "Data read or written in this mutation changed while it was being run";
+const EXECUTION_TIMEOUT_ERROR_PREFIX =
+  "Function execution timed out (maximum duration:";
+const SYSTEM_TIMEOUT_ERROR_SHORT_MESSAGE = "SystemTimeoutError";
+const SYSTEM_TIMEOUT_ERROR_INTERNAL_PREFIX =
+  "Hit maximum total syscall duration (maximum duration:";
+const SYSTEM_TIMEOUT_ERROR_USER_MESSAGE =
+  "Your request timed out performing too many system operations.";
+
+export function chooseBatchSizeAfterSuccess(args: {
+  batchSize: number;
+  metrics?: TransactionMetrics;
+  durationMs: number;
+  lastFailedBatchSize?: number;
+}): { batchSize: number; limitingMetric?: string } {
+  const tightestMetric = getTightestMetric(args.metrics, args.durationMs);
+  const { usedRatio } = tightestMetric;
+  let nextBatchSize = args.batchSize;
+  let limitingMetric: string | undefined;
+
+  if (usedRatio === 0) {
+    nextBatchSize = args.batchSize + 1;
+  } else if (
+    // Assume metric usage scales roughly with batch size. Grow only when one
+    // more document is still projected to stay within the target.
+    (usedRatio * (args.batchSize + 1)) / args.batchSize <=
+    TARGET_USED_RATIO
+  ) {
+    nextBatchSize = Math.max(
+      args.batchSize + 1,
+      Math.floor((args.batchSize * TARGET_USED_RATIO) / usedRatio),
+    );
+  } else if (usedRatio > TARGET_USED_RATIO) {
+    nextBatchSize = Math.max(
+      1,
+      Math.floor((args.batchSize * TARGET_USED_RATIO) / usedRatio),
+    );
+    limitingMetric = tightestMetric.name;
+  }
+
+  const failedUpperBound =
+    args.lastFailedBatchSize !== undefined &&
+    args.lastFailedBatchSize > args.batchSize
+      ? args.lastFailedBatchSize
+      : undefined;
+  if (failedUpperBound !== undefined && nextBatchSize >= failedUpperBound) {
+    nextBatchSize = Math.max(
+      args.batchSize,
+      Math.floor((args.batchSize + failedUpperBound) / 2),
+    );
+    if (nextBatchSize >= failedUpperBound) {
+      nextBatchSize = failedUpperBound - 1;
+    }
+  }
+
+  nextBatchSize = Math.max(1, Math.floor(nextBatchSize));
+  return {
+    batchSize: nextBatchSize,
+    ...(nextBatchSize < args.batchSize && limitingMetric
+      ? { limitingMetric }
+      : {}),
+  };
+}
+
+export function chooseBatchSizeAfterLimitFailure(args: {
+  batchSize: number;
+}): number {
+  return Math.max(1, Math.floor(args.batchSize / 2));
+}
+
+export function getTransactionLimitMetric(
+  error: unknown,
+): KnownTransactionMetricName | undefined {
+  const text = error instanceof Error ? error.message : String(error);
+  for (const metric of knownTransactionMetricNames) {
+    if (
+      TRANSACTION_LIMIT_ERRORS_BY_METRIC[metric].some((message) =>
+        text.includes(message),
+      )
+    ) {
+      return metric;
+    }
+  }
+  return undefined;
+}
+
+export function looksLikeOccError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return (
+    text.includes(OCC_ERROR_SHORT_MESSAGE) ||
+    text.includes(SYSTEM_OCC_ERROR_USER_MESSAGE) ||
+    OCC_ERROR_USER_MESSAGE_PARTS.every((part) => text.includes(part))
+  );
+}
+
+export function looksLikeExecutionTimeout(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.includes(EXECUTION_TIMEOUT_ERROR_PREFIX);
+}
+
+export function looksLikeSystemOperationsTimeout(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return (
+    text.includes(SYSTEM_TIMEOUT_ERROR_SHORT_MESSAGE) ||
+    text.includes(SYSTEM_TIMEOUT_ERROR_INTERNAL_PREFIX) ||
+    text.includes(SYSTEM_TIMEOUT_ERROR_USER_MESSAGE)
+  );
+}
+
+function getTightestMetric(
+  metrics: TransactionMetrics | undefined,
+  durationMs: number,
+): {
+  name: string;
+  usedRatio: number;
+} {
+  let tightest:
+    | {
+        name: string;
+        usedRatio: number;
+      }
+    | undefined;
+  if (metrics) {
+    for (const name of Object.keys(metrics)) {
+      const metric = metrics[name as keyof TransactionMetrics];
+      const used: unknown = metric.used;
+      const remaining: unknown = metric.remaining;
+      if (
+        typeof used !== "number" ||
+        !Number.isFinite(used) ||
+        typeof remaining !== "number" ||
+        !Number.isFinite(remaining) ||
+        !Number.isFinite(used + remaining)
+      ) {
+        continue;
+      }
+      const usedRatio = getUsedRatio({ used, remaining });
+      if (usedRatio === undefined) {
+        continue;
+      }
+      if (!tightest || usedRatio > tightest.usedRatio) {
+        tightest = { name, usedRatio };
+      }
+    }
+  }
+  // This is observed wall time around the nested mutation, not Convex user
+  // execution time. Queueing and syscalls intentionally make the controller
+  // more conservative under load. The outer action handles failures that occur
+  // later, during the enclosing transaction's commit or timeout.
+  const wallTimeRatio =
+    Math.max(0, durationMs) / DOCUMENTED_MUTATION_EXECUTION_LIMIT_MS;
+  return !tightest || wallTimeRatio > tightest.usedRatio
+    ? { name: MUTATION_WALL_TIME_METRIC, usedRatio: wallTimeRatio }
+    : tightest;
+}
+
+function getUsedRatio(metric: {
+  used: number;
+  remaining: number;
+}): number | undefined {
+  const total = metric.used + metric.remaining;
+  if (total <= 0) {
+    return undefined;
+  }
+  return metric.used / total;
+}

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -4,10 +4,12 @@ import {
   anyApi,
   createFunctionHandle,
 } from "convex/server";
+import type { TransactionMetrics } from "convex/server";
+import { ConvexError } from "convex/values";
 import { describe, expect, test, vi } from "vitest";
-import type { MigrationResult } from "../client/index.js";
-import { migrationArgs } from "../shared.js";
-import { api } from "./_generated/api.js";
+import type { MigrationResult, MigrationStatus } from "../client/index.js";
+import { MIGRATION_BATCH_FAILURE, migrationArgs } from "../shared.js";
+import { api, internal } from "./_generated/api.js";
 import { mutation } from "./_generated/server.js";
 import schema from "./schema.js";
 import { modules } from "./setup.test.js";
@@ -34,10 +36,137 @@ export const doneMigration2 = mutation({
   },
 });
 
+export const lowUsageMigration = mutation({
+  args: migrationArgs,
+  handler: async (_ctx, args): Promise<MigrationResult> => {
+    return {
+      isDone: false,
+      continueCursor: "cursor_after_batch",
+      processed: args.batchSize ?? 10,
+      batchSize: args.batchSize,
+      metrics: metricsWithRatio(0.25),
+    };
+  },
+});
+
+export const highUsageMigration = mutation({
+  args: migrationArgs,
+  handler: async (_ctx, args): Promise<MigrationResult> => {
+    return {
+      isDone: false,
+      continueCursor: "cursor_after_batch",
+      processed: args.batchSize ?? 10,
+      batchSize: args.batchSize,
+      metrics: {
+        ...metricsWithRatio(0.25),
+        bytesWritten: {
+          used: 0.9,
+          remaining: 0.1,
+        },
+      },
+    };
+  },
+});
+
+export const transactionLimitMigration = mutation({
+  args: migrationArgs,
+  handler: async (_ctx, args): Promise<MigrationResult> => {
+    if ((args.batchSize ?? 100) > 5) {
+      throw new Error("TooManyDocumentsRead");
+    }
+    return {
+      isDone: true,
+      continueCursor: "done",
+      processed: 5,
+      batchSize: args.batchSize,
+      metrics: metricsWithRatio(0.5),
+    };
+  },
+});
+
+export const unknownLimitMigration = mutation({
+  args: migrationArgs,
+  handler: async (): Promise<MigrationResult> => {
+    throw new Error("TooManyVectorIndexReads");
+  },
+});
+
+export const wrappedTransactionLimitMigration = mutation({
+  args: migrationArgs,
+  handler: async (): Promise<MigrationResult> => {
+    throw new ConvexError({
+      kind: MIGRATION_BATCH_FAILURE,
+      batchSize: 100,
+      message: "TooManyDocumentsRead",
+    });
+  },
+});
+
+export const nullConvexErrorMigration = mutation({
+  args: migrationArgs,
+  handler: async (): Promise<MigrationResult> => {
+    throw new ConvexError(null);
+  },
+});
+
+export const multiRangeMigration = mutation({
+  args: migrationArgs,
+  handler: async (_ctx, args): Promise<MigrationResult> => {
+    if ((args.currentRangeIndex ?? 0) === 0) {
+      return {
+        isDone: false,
+        continueCursor: null,
+        processed: 1,
+        currentRangeIndex: 1,
+        batchSize: args.batchSize,
+        metrics: metricsWithRatio(0.25),
+      };
+    }
+    return {
+      isDone: true,
+      continueCursor: "done",
+      processed: 2,
+      currentRangeIndex: 1,
+      batchSize: args.batchSize,
+      metrics: metricsWithRatio(0.5),
+    };
+  },
+});
+
+export const resetContinuationMigration = mutation({
+  args: migrationArgs,
+  handler: async (_ctx, args): Promise<MigrationResult> => {
+    if (args.cursor === null) {
+      return {
+        isDone: false,
+        continueCursor: "cursor_after_reset_batch",
+        processed: 1,
+        batchSize: args.batchSize,
+        metrics: metricsWithRatio(0.5),
+      };
+    }
+    return {
+      isDone: true,
+      continueCursor: "done",
+      processed: 1,
+      batchSize: args.batchSize,
+      metrics: metricsWithRatio(0.5),
+    };
+  },
+});
+
 const testApi: ApiFromModules<{
   fns: {
     doneMigration: typeof doneMigration;
     doneMigration2: typeof doneMigration2;
+    lowUsageMigration: typeof lowUsageMigration;
+    highUsageMigration: typeof highUsageMigration;
+    transactionLimitMigration: typeof transactionLimitMigration;
+    unknownLimitMigration: typeof unknownLimitMigration;
+    wrappedTransactionLimitMigration: typeof wrappedTransactionLimitMigration;
+    nullConvexErrorMigration: typeof nullConvexErrorMigration;
+    multiRangeMigration: typeof multiRangeMigration;
+    resetContinuationMigration: typeof resetContinuationMigration;
   };
 }>["fns"] = anyApi["lib.test"] as any;
 
@@ -59,6 +188,41 @@ describe("migrate", () => {
     expect(result.next).toBeUndefined();
     expect(result.latestEnd).toBeTypeOf("number");
     expect(result.state).toBe("success");
+  });
+
+  test("does not turn series handoff failures into batch failures", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    await t.run(async (ctx) => {
+      await Promise.all(
+        [1, 2].map(() =>
+          ctx.db.insert("migrations", {
+            name: "duplicateNextMigration",
+            cursor: null,
+            isDone: false,
+            processed: 0,
+            latestStart: Date.now(),
+          }),
+        ),
+      );
+    });
+
+    await expect(
+      t.mutation(api.lib.migrate, {
+        name: "handoffFailure",
+        fnHandle,
+        next: [{ name: "duplicateNextMigration", fnHandle }],
+        dryRun: false,
+      }),
+    ).rejects.toThrow();
+
+    const [status] = await t.query(api.lib.getStatus, {
+      names: ["handoffFailure"],
+    });
+    expect(status?.state).toBe("unknown");
+    expect(status?.processed).toBe(0);
   });
 
   test("throws error for batchSize <= 0", async () => {
@@ -90,6 +254,415 @@ describe("migrate", () => {
     await expect(t.mutation(api.lib.migrate, args)).rejects.toThrow(
       "Invalid fnHandle",
     );
+  });
+
+  test("increases adaptive batch size after a low-usage batch", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.lowUsageMigration),
+    );
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testAdaptiveBatchSize",
+      fnHandle,
+      batchSize: 50,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(100);
+    expect(result.limitingMetric).toBeUndefined();
+    expect(result.state).toBe("unknown");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("records limiting metric after metric-based shrink", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.highUsageMigration),
+    );
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testAdaptiveBatchSizeShrink",
+      fnHandle,
+      batchSize: 50,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(27);
+    expect(result.limitingMetric).toBe("bytesWritten");
+    expect(result.state).toBe("unknown");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("reduces batch size after transaction-limit failure", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.transactionLimitMigration),
+    );
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testTransactionLimitRetry",
+      fnHandle,
+      batchSize: 10,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(5);
+    expect(result.limitingMetric).toBe("documentsRead");
+    expect(result.error).toBeUndefined();
+    expect(result.state).toBe("unknown");
+  });
+
+  test("does not retry an override above a stored failed size of one", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.transactionLimitMigration),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "testTerminalFailedBound",
+        cursor: null,
+        currentRangeIndex: 0,
+        isDone: false,
+        processed: 0,
+        latestStart: Date.now(),
+        currentBatchSize: 1,
+        lastFailedBatchSize: 1,
+      }),
+    );
+
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testTerminalFailedBound",
+      fnHandle,
+      batchSize: 10,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(1);
+    expect(result.limitingMetric).toBe("documentsRead");
+    expect(result.error).toBe("TooManyDocumentsRead");
+    expect(result.state).toBe("failed");
+  });
+
+  test("dry run reports transaction-limit failure instead of retrying silently", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.transactionLimitMigration),
+    );
+    let thrown: unknown;
+
+    try {
+      await t.mutation(api.lib.migrate, {
+        name: "testDryRunTransactionLimitFailure",
+        fnHandle,
+        batchSize: 10,
+        dryRun: true,
+        adaptiveBatchSize: true,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(ConvexError);
+    if (!(thrown instanceof ConvexError)) {
+      throw new Error("Expected dry run ConvexError");
+    }
+    const data = thrown.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new Error("Expected dry run status data");
+    }
+    const record = data as Record<string, unknown>;
+    expect(record.kind).toBe("DRY RUN");
+    const status = record.status as MigrationStatus;
+    expect(status.error).toBe("TooManyDocumentsRead");
+  });
+
+  test("dry run treats non-protocol ConvexError data as a migration failure", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.nullConvexErrorMigration),
+    );
+    let thrown: unknown;
+
+    try {
+      await t.mutation(api.lib.migrate, {
+        name: "testDryRunNullConvexError",
+        fnHandle,
+        dryRun: true,
+        adaptiveBatchSize: true,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(ConvexError);
+    if (!(thrown instanceof ConvexError)) {
+      throw new Error("Expected dry run ConvexError");
+    }
+    const data = thrown.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new Error("Expected dry run status data");
+    }
+    const record = data as Record<string, unknown>;
+    expect(record.kind).toBe("DRY RUN");
+    const status = record.status as MigrationStatus;
+    expect(status.state).toBe("failed");
+    expect(status.error).toBeDefined();
+  });
+
+  test("reduces wrapped default batch size after transaction-limit failure", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.wrappedTransactionLimitMigration),
+    );
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testWrappedTransactionLimitRetry",
+      fnHandle,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(50);
+    expect(result.limitingMetric).toBe("documentsRead");
+    expect(result.error).toBeUndefined();
+    expect(result.state).toBe("unknown");
+  });
+
+  test("stores unknown limit-like failure without retrying", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.unknownLimitMigration),
+    );
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testUnknownLimitFailure",
+      fnHandle,
+      batchSize: 10,
+      dryRun: false,
+      oneBatchOnly: true,
+      adaptiveBatchSize: true,
+    });
+
+    expect(result.batchSize).toBe(10);
+    expect(result.limitingMetric).toBeUndefined();
+    expect(result.error).toBe("TooManyVectorIndexReads");
+    expect(result.state).toBe("failed");
+  });
+
+  test.each([
+    {
+      failure: {
+        kind: "executionTimeout" as const,
+        message: "Function execution timed out (maximum duration: 1s)",
+      },
+      limitingMetric: "mutationUserExecutionTime",
+    },
+    {
+      failure: {
+        kind: "systemOperationsTimeout" as const,
+        message:
+          "Your request timed out performing too many system operations.",
+      },
+      limitingMetric: "mutationSystemOperationsTime",
+    },
+    {
+      failure: {
+        kind: "occ" as const,
+        message: "OptimisticConcurrencyControlFailure",
+      },
+      limitingMetric: "optimisticConcurrencyControl",
+    },
+  ])(
+    "recovers a worker $failure.kind without advancing its cursor",
+    async ({ failure, limitingMetric }) => {
+      const t = convexTest(schema, modules);
+      const fnHandle = await t.run(() =>
+        createFunctionHandle(testApi.doneMigration),
+      );
+      const workerId = await t.run((ctx) =>
+        ctx.scheduler.runAfter(60_000, testApi.doneMigration, {}),
+      );
+      await t.run((ctx) =>
+        ctx.db.insert("migrations", {
+          name: "outerFailureRecovery",
+          cursor: "cursor_before_failed_batch",
+          currentRangeIndex: 2,
+          isDone: false,
+          processed: 25,
+          latestStart: Date.now(),
+          currentBatchSize: 10,
+          workerId,
+          workerGeneration: 3,
+        }),
+      );
+
+      const result = await t.mutation(internal.lib.recoverWorkerFailure, {
+        migration: {
+          name: "outerFailureRecovery",
+          fnHandle,
+          cursor: "cursor_before_failed_batch",
+          currentRangeIndex: 2,
+          batchSize: 10,
+          dryRun: false,
+          adaptiveBatchSize: true,
+          workerGeneration: 3,
+        },
+        failure,
+      });
+
+      expect(result.cursor).toBe("cursor_before_failed_batch");
+      expect(result.currentRangeIndex).toBe(2);
+      expect(result.processed).toBe(25);
+      expect(result.batchSize).toBe(5);
+      expect(result.limitingMetric).toBe(limitingMetric);
+      expect(result.state).toBe("inProgress");
+      expect(result.error).toBeUndefined();
+    },
+  );
+
+  test("does not retry a worker above a stored failed size of one", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    const workerId = await t.run((ctx) =>
+      ctx.scheduler.runAfter(60_000, testApi.doneMigration, {}),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "terminalOuterFailure",
+        cursor: "cursor_before_failed_batch",
+        currentRangeIndex: 2,
+        isDone: false,
+        processed: 25,
+        latestStart: Date.now(),
+        currentBatchSize: 1,
+        lastFailedBatchSize: 1,
+        workerId,
+        workerGeneration: 3,
+      }),
+    );
+
+    const result = await t.mutation(internal.lib.recoverWorkerFailure, {
+      migration: {
+        name: "terminalOuterFailure",
+        fnHandle,
+        cursor: "cursor_before_failed_batch",
+        currentRangeIndex: 2,
+        batchSize: 10,
+        dryRun: false,
+        adaptiveBatchSize: true,
+        workerGeneration: 3,
+      },
+      failure: {
+        kind: "executionTimeout",
+        message: "Function execution timed out (maximum duration: 1s)",
+      },
+    });
+
+    expect(result.cursor).toBe("cursor_before_failed_batch");
+    expect(result.currentRangeIndex).toBe(2);
+    expect(result.processed).toBe(25);
+    expect(result.batchSize).toBe(1);
+    expect(result.limitingMetric).toBe("mutationUserExecutionTime");
+    expect(result.state).toBe("failed");
+    expect(result.error).toBe(
+      "Function execution timed out (maximum duration: 1s)",
+    );
+  });
+
+  test("ignores recovery from a stale worker generation", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    const workerId = await t.run((ctx) =>
+      ctx.scheduler.runAfter(60_000, testApi.doneMigration, {}),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "staleOuterFailure",
+        cursor: "newer_cursor",
+        currentRangeIndex: 1,
+        isDone: false,
+        processed: 50,
+        latestStart: Date.now(),
+        currentBatchSize: 8,
+        workerId,
+        workerGeneration: 4,
+      }),
+    );
+
+    const result = await t.mutation(internal.lib.recoverWorkerFailure, {
+      migration: {
+        name: "staleOuterFailure",
+        fnHandle,
+        cursor: "older_cursor",
+        currentRangeIndex: 0,
+        batchSize: 10,
+        dryRun: false,
+        adaptiveBatchSize: true,
+        workerGeneration: 3,
+      },
+      failure: {
+        kind: "executionTimeout",
+        message: "Function execution timed out (maximum duration: 1s)",
+      },
+    });
+
+    expect(result.cursor).toBe("newer_cursor");
+    expect(result.currentRangeIndex).toBe(1);
+    expect(result.processed).toBe(50);
+    expect(result.batchSize).toBe(8);
+    expect(result.limitingMetric).toBeUndefined();
+  });
+
+  test("persists current range index across batches", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.multiRangeMigration),
+    );
+    const first = await t.mutation(api.lib.migrate, {
+      name: "testMultiRange",
+      fnHandle,
+      batchSize: 10,
+      dryRun: false,
+      oneBatchOnly: true,
+    });
+
+    expect(first.isDone).toBe(false);
+    expect(first.cursor).toBe(null);
+    expect(first.currentRangeIndex).toBe(1);
+    expect(first.processed).toBe(1);
+    expect(first.batchSize).toBe(10);
+
+    await t.run(async (ctx) => {
+      const state = await ctx.db
+        .query("migrations")
+        .withIndex("name", (q) => q.eq("name", "testMultiRange"))
+        .unique();
+      await ctx.db.patch("migrations", state!._id, {
+        limitingMetric: "documentsRead",
+      });
+    });
+
+    const second = await t.mutation(api.lib.migrate, {
+      name: "testMultiRange",
+      fnHandle,
+      batchSize: 10,
+      dryRun: false,
+      oneBatchOnly: true,
+    });
+
+    expect(second.isDone).toBe(true);
+    expect(second.currentRangeIndex).toBe(1);
+    expect(second.processed).toBe(3);
+    expect(second.limitingMetric).toBe("documentsRead");
   });
 });
 
@@ -146,6 +719,40 @@ describe("cancel", () => {
       names: ["testCancelMigration"],
     });
     expect(status[0]?.state).toBe("canceled");
+  });
+
+  test("oneBatchOnly call does not run beside an active scheduled worker", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(inProgressApi.inProgressMigration),
+    );
+
+    const first = await t.mutation(api.lib.migrate, {
+      name: "testOneBatchOnlyRace",
+      fnHandle,
+      dryRun: false,
+      oneBatchOnly: false,
+    });
+    expect(first.state).toBe("inProgress");
+    expect(first.cursor).toBe("cursor_after_10");
+    expect(first.processed).toBe(10);
+
+    const duplicate = await t.mutation(api.lib.migrate, {
+      name: "testOneBatchOnlyRace",
+      fnHandle,
+      cursor: "cursor_after_10",
+      dryRun: false,
+      oneBatchOnly: true,
+    });
+
+    expect(duplicate.state).toBe("inProgress");
+    expect(duplicate.processed).toBe(10);
+
+    const [status] = await t.query(api.lib.getStatus, {
+      names: ["testOneBatchOnlyRace"],
+    });
+    expect(status?.state).toBe("inProgress");
+    expect(status?.processed).toBe(10);
   });
 
   test("canceled migration can be restarted", async () => {
@@ -362,6 +969,49 @@ describe("reset", () => {
     expect(statuses[0]!.cursor).toBe(null);
   });
 
+  test("without reset, partially-done next migration resumes stored range", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const fnHandle1 = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    const fnHandle2 = await t.run(() =>
+      createFunctionHandle(testApi.multiRangeMigration),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "migration2",
+        latestStart: 1,
+        latestEnd: 2,
+        error: "previous failure",
+        isDone: false,
+        cursor: null,
+        currentRangeIndex: 1,
+        processed: 10,
+      }),
+    );
+
+    await t.mutation(api.lib.migrate, {
+      name: "migration1",
+      fnHandle: fnHandle1,
+      next: [{ name: "migration2", fnHandle: fnHandle2 }],
+      dryRun: false,
+    });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [status] = await t.query(api.lib.getStatus, {
+      names: ["migration2"],
+    });
+    expect(status?.isDone).toBe(true);
+    expect(status?.currentRangeIndex).toBe(1);
+    expect(status?.processed).toBe(12);
+    expect(status?.error).toBeUndefined();
+    expect(status?.latestStart).not.toBe(1);
+    expect(status?.latestEnd).not.toBe(2);
+    vi.useRealTimers();
+  });
+
   test("reset on a fresh migration (no prior state) works", async () => {
     const t = convexTest(schema, modules);
     const fnHandle = await t.run(() =>
@@ -379,4 +1029,230 @@ describe("reset", () => {
     expect(result.processed).toBe(1);
     expect(result.state).toBe("success");
   });
+
+  test("reset re-runs a completed migration whose cursor is already null", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "testMigration",
+        latestStart: Date.now(),
+        isDone: true,
+        cursor: null,
+        processed: 5,
+      }),
+    );
+
+    const result = await t.mutation(api.lib.migrate, {
+      name: "testMigration",
+      fnHandle,
+      cursor: null,
+      reset: true,
+      dryRun: false,
+    });
+
+    expect(result.isDone).toBe(true);
+    expect(result.processed).toBe(1);
+  });
+
+  test("reset scheduled continuation runs the next batch", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.resetContinuationMigration),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "resetContinuation",
+        latestStart: Date.now(),
+        isDone: false,
+        cursor: "oldCursor",
+        processed: 10,
+      }),
+    );
+
+    const first = await t.mutation(api.lib.migrate, {
+      name: "resetContinuation",
+      fnHandle,
+      cursor: null,
+      reset: true,
+      dryRun: false,
+    });
+    expect(first.isDone).toBe(false);
+    expect(first.processed).toBe(1);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [status] = await t.query(api.lib.getStatus, {
+      names: ["resetContinuation"],
+    });
+    expect(status?.isDone).toBe(true);
+    expect(status?.processed).toBe(2);
+    vi.useRealTimers();
+  });
+
+  test("reset replaces an active worker and invalidates its recovery", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    const workerId = await t.run((ctx) =>
+      ctx.scheduler.runAfter(60_000, testApi.doneMigration, {}),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "resetActiveWorker",
+        latestStart: Date.now(),
+        isDone: false,
+        cursor: "oldCursor",
+        processed: 10,
+        workerId,
+        workerGeneration: 3,
+      }),
+    );
+
+    const reset = await t.mutation(api.lib.migrate, {
+      name: "resetActiveWorker",
+      fnHandle,
+      cursor: null,
+      reset: true,
+      batchSize: 10,
+      dryRun: false,
+    });
+
+    expect(reset.state).toBe("success");
+    expect(reset.processed).toBe(1);
+
+    const staleRecovery = await t.mutation(internal.lib.recoverWorkerFailure, {
+      migration: {
+        name: "resetActiveWorker",
+        fnHandle,
+        cursor: "oldCursor",
+        batchSize: 10,
+        dryRun: false,
+        adaptiveBatchSize: true,
+        workerGeneration: 3,
+      },
+      failure: {
+        kind: "executionTimeout",
+        message: "Function execution timed out (maximum duration: 1s)",
+      },
+    });
+
+    expect(staleRecovery.state).toBe("success");
+    expect(staleRecovery.processed).toBe(1);
+    expect(staleRecovery.error).toBeUndefined();
+  });
+
+  test("manual resume invalidates a canceled worker's recovery", async () => {
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.doneMigration),
+    );
+    const workerId = await t.run(async (ctx) => {
+      const id = await ctx.scheduler.runAfter(
+        60_000,
+        testApi.doneMigration,
+        {},
+      );
+      await ctx.scheduler.cancel(id);
+      return id;
+    });
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "resumeCanceledWorker",
+        latestStart: Date.now(),
+        isDone: false,
+        cursor: "storedCursor",
+        processed: 10,
+        workerId,
+        workerGeneration: 3,
+      }),
+    );
+
+    const resumed = await t.mutation(api.lib.migrate, {
+      name: "resumeCanceledWorker",
+      fnHandle,
+      dryRun: false,
+    });
+    expect(resumed.state).toBe("success");
+    expect(resumed.processed).toBe(11);
+
+    const staleRecovery = await t.mutation(internal.lib.recoverWorkerFailure, {
+      migration: {
+        name: "resumeCanceledWorker",
+        fnHandle,
+        cursor: "storedCursor",
+        batchSize: 10,
+        dryRun: false,
+        adaptiveBatchSize: true,
+        workerGeneration: 3,
+      },
+      failure: {
+        kind: "executionTimeout",
+        message: "Function execution timed out (maximum duration: 1s)",
+      },
+    });
+
+    expect(staleRecovery.state).toBe("success");
+    expect(staleRecovery.processed).toBe(11);
+    expect(staleRecovery.error).toBeUndefined();
+  });
+
+  test("reset transaction-limit retry runs at the smaller batch size", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const fnHandle = await t.run(() =>
+      createFunctionHandle(testApi.transactionLimitMigration),
+    );
+    await t.run((ctx) =>
+      ctx.db.insert("migrations", {
+        name: "resetLimitRetry",
+        latestStart: Date.now(),
+        isDone: false,
+        cursor: "oldCursor",
+        processed: 10,
+      }),
+    );
+
+    const first = await t.mutation(api.lib.migrate, {
+      name: "resetLimitRetry",
+      fnHandle,
+      cursor: null,
+      reset: true,
+      batchSize: 10,
+      dryRun: false,
+      adaptiveBatchSize: true,
+    });
+    expect(first.isDone).toBe(false);
+    expect(first.batchSize).toBe(5);
+    expect(first.limitingMetric).toBe("documentsRead");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [status] = await t.query(api.lib.getStatus, {
+      names: ["resetLimitRetry"],
+    });
+    expect(status?.isDone).toBe(true);
+    expect(status?.processed).toBe(5);
+    vi.useRealTimers();
+  });
 });
+
+function metricsWithRatio(ratio: number): TransactionMetrics {
+  const metric = {
+    used: ratio,
+    remaining: 1 - ratio,
+  };
+  return {
+    bytesRead: metric,
+    bytesWritten: metric,
+    databaseQueries: metric,
+    documentsRead: metric,
+    documentsWritten: metric,
+    functionsScheduled: metric,
+    scheduledFunctionArgsBytes: metric,
+  };
+}

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -1,19 +1,39 @@
-import type { FunctionHandle, WithoutSystemFields } from "convex/server";
+import {
+  type FunctionHandle,
+  type FunctionReference,
+  makeFunctionReference,
+  type WithoutSystemFields,
+} from "convex/server";
 import { ConvexError, type ObjectType, v } from "convex/values";
 import {
+  MIGRATION_BATCH_FAILURE,
   type MigrationArgs,
   type MigrationResult,
   type MigrationStatus,
+  getMigrationDryRunResult,
   migrationStatus,
 } from "../shared.js";
 import { api } from "./_generated/api.js";
 import type { Doc } from "./_generated/dataModel.js";
 import {
+  internalAction,
+  internalMutation,
   mutation,
   type MutationCtx,
   query,
   type QueryCtx,
 } from "./_generated/server.js";
+import {
+  chooseBatchSizeAfterLimitFailure,
+  chooseBatchSizeAfterSuccess,
+  getTransactionLimitMetric,
+  looksLikeExecutionTimeout,
+  looksLikeOccError,
+  looksLikeSystemOperationsTimeout,
+  MUTATION_SYSTEM_OPERATIONS_TIME_METRIC,
+  MUTATION_USER_EXECUTION_TIME_METRIC,
+  OCC_LIMITING_METRIC,
+} from "./batchSize.js";
 
 export type MigrationFunctionHandle = FunctionHandle<
   "mutation",
@@ -21,13 +41,13 @@ export type MigrationFunctionHandle = FunctionHandle<
   MigrationResult
 >;
 
-const runMigrationArgs = {
+const migrationInvocationArgs = {
   name: v.string(),
   fnHandle: v.string(),
   cursor: v.optional(v.union(v.string(), v.null())),
 
   batchSize: v.optional(v.number()),
-  oneBatchOnly: v.optional(v.boolean()),
+  initialBatchSize: v.optional(v.number()),
   next: v.optional(
     v.array(
       v.object({
@@ -38,7 +58,77 @@ const runMigrationArgs = {
   ),
   dryRun: v.boolean(),
   reset: v.optional(v.boolean()),
+  adaptiveBatchSize: v.optional(v.boolean()),
+  currentRangeIndex: v.optional(v.number()),
 };
+
+const scheduledMigrationArgs = {
+  ...migrationInvocationArgs,
+  workerGeneration: v.number(),
+};
+
+const runMigrationArgs = {
+  ...migrationInvocationArgs,
+  oneBatchOnly: v.optional(v.boolean()),
+  workerGeneration: v.optional(v.number()),
+};
+
+const workerFailure = v.union(
+  v.object({
+    kind: v.literal("transactionLimit"),
+    limitingMetric: v.string(),
+    message: v.string(),
+  }),
+  v.object({
+    kind: v.literal("occ"),
+    message: v.string(),
+  }),
+  v.object({
+    kind: v.literal("executionTimeout"),
+    message: v.string(),
+  }),
+  v.object({
+    kind: v.literal("systemOperationsTimeout"),
+    message: v.string(),
+  }),
+  v.object({
+    kind: v.literal("unknown"),
+    message: v.string(),
+  }),
+);
+
+type ScheduledMigrationArgs = ObjectType<typeof scheduledMigrationArgs>;
+type WorkerScheduleArgs = Omit<ScheduledMigrationArgs, "workerGeneration">;
+type WorkerFailure = ObjectType<{ failure: typeof workerFailure }>["failure"];
+
+// Generated API types import this module, so referring to these same-module
+// internal functions through `internal` would create circular type inference.
+const runWorkerFunction = makeFunctionReference<
+  "action",
+  ScheduledMigrationArgs,
+  MigrationStatus
+>("lib:runWorker") as unknown as FunctionReference<
+  "action",
+  "internal",
+  ScheduledMigrationArgs,
+  MigrationStatus
+>;
+const recoverWorkerFailureFunction = makeFunctionReference<
+  "mutation",
+  {
+    migration: ScheduledMigrationArgs;
+    failure: WorkerFailure;
+  },
+  MigrationStatus
+>("lib:recoverWorkerFailure") as unknown as FunctionReference<
+  "mutation",
+  "internal",
+  {
+    migration: ScheduledMigrationArgs;
+    failure: WorkerFailure;
+  },
+  MigrationStatus
+>;
 
 export const migrate = mutation({
   args: runMigrationArgs,
@@ -46,8 +136,29 @@ export const migrate = mutation({
   handler: async (ctx, args) => {
     // Step 1: Get or create the state.
     const { fnHandle, batchSize, next: next_, dryRun, name } = args;
+    if (batchSize !== undefined && !Number.isInteger(batchSize)) {
+      throw new Error("Batch size must be an integer");
+    }
     if (batchSize !== undefined && batchSize <= 0) {
       throw new Error("Batch size must be greater than 0");
+    }
+    if (
+      args.initialBatchSize !== undefined &&
+      !Number.isInteger(args.initialBatchSize)
+    ) {
+      throw new Error("Initial batch size must be an integer");
+    }
+    if (args.initialBatchSize !== undefined && args.initialBatchSize <= 0) {
+      throw new Error("Initial batch size must be greater than 0");
+    }
+    if (
+      args.currentRangeIndex !== undefined &&
+      !Number.isInteger(args.currentRangeIndex)
+    ) {
+      throw new Error("Current range index must be an integer");
+    }
+    if (args.currentRangeIndex !== undefined && args.currentRangeIndex < 0) {
+      throw new Error("Current range index must be non-negative");
     }
     if (!fnHandle.startsWith("function://")) {
       throw new Error(
@@ -69,71 +180,281 @@ export const migrate = mutation({
           cursor: args.cursor ?? null,
           isDone: false,
           processed: 0,
+          currentRangeIndex: args.currentRangeIndex ?? 0,
           latestStart: Date.now(),
+          currentBatchSize: batchSize ?? args.initialBatchSize,
+          workerGeneration: args.workerGeneration,
         }),
       ))!;
+    const adaptiveBatchSize = args.adaptiveBatchSize !== false;
+    const currentRangeIndexDiffers =
+      args.currentRangeIndex !== undefined &&
+      (state.currentRangeIndex ?? 0) !== args.currentRangeIndex;
+    // Reset is a start-position instruction for this invocation. Same-migration
+    // continuations and retries must resume the stored reset point, while next
+    // migrations still receive reset below when the whole series is reset.
+    const {
+      reset: _reset,
+      workerGeneration: _workerGeneration,
+      oneBatchOnly: _oneBatchOnly,
+      ...sameMigrationArgs
+    } = args;
+    const positionDiffers =
+      args.reset || state.cursor !== args.cursor || currentRangeIndexDiffers;
+    const shouldCheckActiveWorker =
+      args.workerGeneration === undefined &&
+      (args.oneBatchOnly || positionDiffers);
+    const worker =
+      shouldCheckActiveWorker && state.workerId
+        ? await ctx.db.system.get("_scheduled_functions", state.workerId)
+        : undefined;
+    let invalidatedWorkerGeneration = false;
 
-    // Update the state if the cursor arg differs.
-    if (state.cursor !== args.cursor) {
+    // Check for an active worker before accepting a position-changing call or
+    // an external oneBatchOnly call.
+    if (shouldCheckActiveWorker) {
       // This happens if:
-      // 1. The migration is being started/resumed (args.cursor unset).
-      // 2. The migration is being resumed at a different cursor.
-      // 3. There are two instances of the same migration racing.
-      const worker =
-        state.workerId &&
-        (await ctx.db.system.get("_scheduled_functions", state.workerId));
+      // 1. The migration is being reset.
+      // 2. The migration is being started/resumed (args.cursor unset).
+      // 3. The migration is being resumed at a different cursor.
+      // 4. A oneBatchOnly caller is racing with the scheduled continuation.
+      // 5. There are two instances of the same migration racing.
       if (
         worker &&
         (worker.state.kind === "pending" || worker.state.kind === "inProgress")
       ) {
-        // Case 3. The migration is already in progress.
-        console.debug({ state, worker });
-        return getMigrationState(ctx, state);
+        if (
+          args.reset &&
+          state.workerId &&
+          state.workerGeneration !== undefined
+        ) {
+          await ctx.scheduler.cancel(state.workerId);
+        } else {
+          // oneBatchOnly calls are external calls, not scheduled continuations.
+          // They must not run beside an active worker even when they pass the
+          // same stored cursor.
+          console.debug({ state, worker });
+          return getMigrationState(ctx, state);
+        }
       }
-      // Case 2. Update the cursor.
-      if (args.cursor !== undefined) {
-        state.cursor = args.cursor;
+    }
+    if (
+      shouldCheckActiveWorker &&
+      args.workerGeneration === undefined &&
+      state.workerId !== undefined
+    ) {
+      // An external call that takes over from a completed, failed, or canceled
+      // worker must also make that worker's late recovery stale.
+      state.workerGeneration = (state.workerGeneration ?? 0) + 1;
+      invalidatedWorkerGeneration = true;
+    }
+    if (
+      args.workerGeneration === undefined &&
+      !state.isDone &&
+      (invalidatedWorkerGeneration || state.error !== undefined)
+    ) {
+      state.latestStart = Date.now();
+      state.latestEnd = undefined;
+    }
+    if (
+      args.workerGeneration !== undefined &&
+      !(await claimWorker(ctx, state, args.workerGeneration))
+    ) {
+      return getMigrationState(ctx, state);
+    }
+    if (positionDiffers) {
+      // A missing cursor means "resume stored progress". Only an explicit
+      // cursor, reset, or explicit range index may rewrite the stored position;
+      // this preserves multi-range handoff where the cursor is null but the
+      // current range has already advanced.
+      if (args.reset || args.cursor !== undefined || currentRangeIndexDiffers) {
+        if (
+          args.workerGeneration === undefined &&
+          !invalidatedWorkerGeneration
+        ) {
+          // An external position change takes ownership from every older
+          // worker, including one canceled just before this transaction. Keep
+          // it stale even if this call finishes without scheduling a worker.
+          state.workerGeneration = (state.workerGeneration ?? 0) + 1;
+        }
+        state.cursor = args.cursor ?? null;
         state.isDone = false;
         state.latestStart = Date.now();
         state.latestEnd = undefined;
         state.processed = 0;
+        state.currentRangeIndex = args.reset
+          ? 0
+          : (args.currentRangeIndex ?? 0);
+        state.error = undefined;
+        state.workerId = undefined;
+        state.currentBatchSize = batchSize ?? args.initialBatchSize;
+        state.lastFailedBatchSize = undefined;
+        state.limitingMetric = undefined;
       }
-      // For Case 1, Step 2 will take the right action.
+      // For Case 2, Step 2 will take the right action.
     }
 
-    function updateState(result: MigrationResult) {
+    function updateState(result: MigrationResult, durationMs: number) {
+      const completedBatchSize =
+        result.batchSize ??
+        batchSize ??
+        state.currentBatchSize ??
+        args.initialBatchSize;
       state.cursor = result.continueCursor;
       state.isDone = result.isDone;
       state.processed += result.processed;
+      state.currentRangeIndex =
+        result.currentRangeIndex ?? state.currentRangeIndex ?? 0;
+      if (completedBatchSize !== undefined) {
+        const fullBatch = result.processed >= completedBatchSize;
+        if (fullBatch) {
+          const lastFailedBatchSize =
+            state.lastFailedBatchSize !== undefined &&
+            completedBatchSize < state.lastFailedBatchSize
+              ? state.lastFailedBatchSize
+              : undefined;
+          // A successful explicit/default-size run at or above a previous
+          // failure disproves that failed size as an adaptive upper bound.
+          state.lastFailedBatchSize = lastFailedBatchSize;
+          if (adaptiveBatchSize) {
+            const next = chooseBatchSizeAfterSuccess({
+              batchSize: completedBatchSize,
+              metrics: result.metrics,
+              durationMs,
+              lastFailedBatchSize,
+            });
+            state.currentBatchSize = next.batchSize;
+            state.limitingMetric = next.limitingMetric;
+          } else {
+            state.currentBatchSize = completedBatchSize;
+            state.limitingMetric = undefined;
+          }
+        } else {
+          // An underfilled page does not measure the cost of the requested
+          // batch size. Preserve the prior bound and limiting metric.
+          state.currentBatchSize = completedBatchSize;
+        }
+      }
       if (result.isDone && state.latestEnd === undefined) {
         state.latestEnd = Date.now();
       }
     }
 
-    try {
-      // Step 2: Run the migration.
-      if (!state.isDone) {
-        const result = await ctx.runMutation(
+    // Step 2: Run the migration. Only failures from this nested call belong to
+    // the adaptive retry contract. Handoff and scheduling failures below must
+    // abort this transaction so its successful batch is not recorded twice.
+    let batchFailed = false;
+    if (!state.isDone) {
+      const batchSizeToRun =
+        batchSize ?? state.currentBatchSize ?? args.initialBatchSize;
+      const startedAt = performance.now();
+      let successfulResult: MigrationResult | undefined;
+      try {
+        successfulResult = await ctx.runMutation(
           fnHandle as MigrationFunctionHandle,
           {
             cursor: state.cursor,
-            batchSize,
+            currentRangeIndex: state.currentRangeIndex ?? 0,
+            batchSize: batchSizeToRun,
             dryRun,
             oneBatchOnly: true,
           },
         );
-        updateState(result);
+      } catch (e) {
+        batchFailed = true;
+        state.workerId = undefined;
+        // Defined migration wrappers attach the attempted size because a
+        // failed child cannot return it in the normal result.
+        const migrationBatchFailure = getMigrationBatchFailure(e);
+        const retryableError = migrationBatchFailure?.message ?? e;
+        const transactionLimitMetric =
+          getTransactionLimitMetric(retryableError);
+        const failedBatchSize =
+          migrationBatchFailure?.batchSize ??
+          batchSize ??
+          state.currentBatchSize ??
+          args.initialBatchSize;
+        const failedUpperBound =
+          transactionLimitMetric !== undefined &&
+          failedBatchSize !== undefined
+            ? Math.min(
+                failedBatchSize,
+                state.lastFailedBatchSize ?? failedBatchSize,
+              )
+            : undefined;
+        // An explicit override can exceed a smaller stored failed bound. Branch on the smallest
+        // known failure so a size-1 failure remains terminal instead of becoming retryable again.
+        const dryRunResult = dryRun ? getMigrationDryRunResult(e) : undefined;
+        if (dryRunResult !== undefined) {
+          // Add the state to the error to bubble up.
+          updateState(dryRunResult, 0);
+        } else if (
+          !dryRun &&
+          failedUpperBound !== undefined &&
+          failedUpperBound > 1
+        ) {
+          const nextBatchSize = chooseBatchSizeAfterLimitFailure({
+            batchSize: failedUpperBound,
+          });
+          state.currentBatchSize = nextBatchSize;
+          state.lastFailedBatchSize = failedUpperBound;
+          state.limitingMetric = transactionLimitMetric;
+          state.latestEnd = undefined;
+          state.error = undefined;
+          if (!args.oneBatchOnly) {
+            await scheduleWorker(ctx, state, {
+              ...sameMigrationArgs,
+              cursor: state.cursor,
+              currentRangeIndex: state.currentRangeIndex ?? 0,
+              batchSize: nextBatchSize,
+              adaptiveBatchSize,
+            });
+          }
+        } else {
+          if (failedUpperBound !== undefined) {
+            state.currentBatchSize = failedUpperBound;
+            state.lastFailedBatchSize = failedUpperBound;
+          }
+          state.limitingMetric = transactionLimitMetric;
+          state.error =
+            migrationBatchFailure?.message ??
+            (e instanceof Error ? e.message : String(e));
+          state.latestEnd = Date.now();
+          console.error(`Migration ${name} failed: ${state.error}`);
+        }
+        if (dryRun) {
+          const status = await getMigrationState(ctx, state);
+          status.batchSize = state.currentBatchSize ?? batchSize;
+          status.next = next_?.map((n) => n.name);
+          throw new ConvexError({
+            kind: "DRY RUN",
+            status,
+          });
+        }
+      }
+      if (!batchFailed) {
+        if (successfulResult === undefined) {
+          throw new Error("Migration returned undefined");
+        }
+        updateState(successfulResult, performance.now() - startedAt);
         state.error = undefined;
       }
+    }
 
-      // Step 3: Schedule the next batch or next migration.
+    // Step 3: Schedule the next batch or next migration after a successful
+    // batch. Retryable failures already scheduled their smaller retry above.
+    if (!batchFailed) {
       if (args.oneBatchOnly) {
         state.workerId = undefined;
       } else if (!state.isDone) {
-        // Recursively schedule the next batch.
-        state.workerId = await ctx.scheduler.runAfter(0, api.lib.migrate, {
-          ...args,
+        // Run the next controller mutation from an action so failures from its
+        // outer transaction boundary are catchable.
+        await scheduleWorker(ctx, state, {
+          ...sameMigrationArgs,
           cursor: state.cursor,
+          currentRangeIndex: state.currentRangeIndex ?? 0,
+          batchSize: adaptiveBatchSize ? state.currentBatchSize : batchSize,
+          adaptiveBatchSize,
         });
       } else {
         state.workerId = undefined;
@@ -149,14 +470,45 @@ export const migrate = mutation({
           if (args.reset || !doc || !doc.isDone) {
             const [nextFn, ...rest] = next.slice(i);
             if (nextFn) {
-              await ctx.scheduler.runAfter(0, api.lib.migrate, {
+              const now = Date.now();
+              const nextState =
+                doc ??
+                (await ctx.db.get(
+                  "migrations",
+                  await ctx.db.insert("migrations", {
+                    name: nextFn.name,
+                    cursor: null,
+                    isDone: false,
+                    processed: 0,
+                    currentRangeIndex: 0,
+                    latestStart: now,
+                    currentBatchSize: adaptiveBatchSize ? undefined : batchSize,
+                  }),
+                ))!;
+              if (args.reset) {
+                nextState.cursor = null;
+                nextState.currentRangeIndex = 0;
+                nextState.isDone = false;
+                nextState.processed = 0;
+                nextState.currentBatchSize = adaptiveBatchSize
+                  ? undefined
+                  : batchSize;
+                nextState.lastFailedBatchSize = undefined;
+                nextState.limitingMetric = undefined;
+              }
+              nextState.latestStart = now;
+              nextState.latestEnd = undefined;
+              nextState.error = undefined;
+              await scheduleWorker(ctx, nextState, {
                 name: nextFn.name,
                 fnHandle: nextFn.fnHandle,
                 next: rest,
-                batchSize,
-                dryRun,
+                dryRun: false,
+                batchSize: adaptiveBatchSize ? undefined : batchSize,
+                adaptiveBatchSize,
                 ...(args.reset ? { reset: true, cursor: null } : {}),
               });
+              await ctx.db.patch("migrations", nextState._id, nextState);
             }
             break;
           }
@@ -172,24 +524,6 @@ export const migrate = mutation({
           );
         }
       }
-    } catch (e) {
-      state.workerId = undefined;
-      if (dryRun && e instanceof ConvexError && e.data.kind === "DRY RUN") {
-        // Add the state to the error to bubble up.
-        updateState(e.data.result);
-      } else {
-        state.error = e instanceof Error ? e.message : String(e);
-        console.error(`Migration ${name} failed: ${state.error}`);
-      }
-      if (dryRun) {
-        const status = await getMigrationState(ctx, state);
-        status.batchSize = batchSize;
-        status.next = next_?.map((n) => n.name);
-        throw new ConvexError({
-          kind: "DRY RUN",
-          status,
-        });
-      }
     }
 
     // Step 4: Update the state
@@ -202,6 +536,124 @@ export const migrate = mutation({
         "Error: Dry run attempted to update state - rolling back transaction.",
       );
     }
+    return getMigrationState(ctx, state);
+  },
+});
+
+export const runWorker = internalAction({
+  args: scheduledMigrationArgs,
+  returns: migrationStatus,
+  handler: async (ctx, args): Promise<MigrationStatus> => {
+    if (args.dryRun) {
+      throw new Error("Scheduled migration workers cannot run dry runs");
+    }
+    try {
+      return await ctx.runMutation(api.lib.migrate, args);
+    } catch (error) {
+      return await ctx.runMutation(recoverWorkerFailureFunction, {
+        migration: args,
+        failure: classifyWorkerFailure(error),
+      });
+    }
+  },
+});
+
+export const recoverWorkerFailure = internalMutation({
+  args: {
+    migration: v.object(scheduledMigrationArgs),
+    failure: workerFailure,
+  },
+  returns: migrationStatus,
+  handler: async (ctx, { migration: args, failure }) => {
+    let state = await ctx.db
+      .query("migrations")
+      .withIndex("name", (q) => q.eq("name", args.name))
+      .unique();
+    if (state === null) {
+      const id = await ctx.db.insert("migrations", {
+        name: args.name,
+        cursor: args.cursor ?? null,
+        isDone: false,
+        processed: 0,
+        currentRangeIndex: args.currentRangeIndex ?? 0,
+        latestStart: Date.now(),
+        currentBatchSize: args.batchSize ?? args.initialBatchSize,
+        workerGeneration: args.workerGeneration,
+      });
+      state = (await ctx.db.get("migrations", id))!;
+    }
+
+    if (!(await claimWorker(ctx, state, args.workerGeneration))) {
+      return getMigrationState(ctx, state);
+    }
+
+    if (args.reset) {
+      state.cursor = args.cursor ?? null;
+      state.currentRangeIndex = args.currentRangeIndex ?? 0;
+      state.isDone = false;
+      state.processed = 0;
+      state.latestStart = Date.now();
+      state.latestEnd = undefined;
+      state.currentBatchSize = args.batchSize ?? args.initialBatchSize;
+      state.lastFailedBatchSize = undefined;
+      state.limitingMetric = undefined;
+    } else if (
+      (args.cursor !== undefined && state.cursor !== args.cursor) ||
+      (args.currentRangeIndex !== undefined &&
+        (state.currentRangeIndex ?? 0) !== args.currentRangeIndex)
+    ) {
+      return getMigrationState(ctx, state);
+    }
+
+    const limitingMetric = getWorkerFailureMetric(failure);
+    const failedBatchSize =
+      args.batchSize ?? state.currentBatchSize ?? args.initialBatchSize;
+    const failedUpperBound =
+      failure.kind !== "unknown" && failedBatchSize !== undefined
+        ? Math.min(
+            failedBatchSize,
+            state.lastFailedBatchSize ?? failedBatchSize,
+          )
+        : undefined;
+    // An explicit override can exceed a smaller stored failed bound. Branch on the smallest known
+    // failure so a size-1 failure remains terminal instead of becoming retryable again.
+    if (
+      failedUpperBound !== undefined &&
+      failedUpperBound > 1
+    ) {
+      const nextBatchSize = chooseBatchSizeAfterLimitFailure({
+        batchSize: failedUpperBound,
+      });
+      const {
+        reset: _reset,
+        workerGeneration: _workerGeneration,
+        ...sameMigrationArgs
+      } = args;
+      await scheduleWorker(ctx, state, {
+        ...sameMigrationArgs,
+        cursor: state.cursor,
+        currentRangeIndex: state.currentRangeIndex ?? 0,
+        batchSize: nextBatchSize,
+        dryRun: false,
+      });
+      state.error = undefined;
+      state.latestEnd = undefined;
+      state.currentBatchSize = nextBatchSize;
+      state.lastFailedBatchSize = failedUpperBound;
+      state.limitingMetric = limitingMetric;
+      await ctx.db.patch("migrations", state._id, state);
+      return getMigrationState(ctx, state);
+    }
+
+    state.workerId = undefined;
+    if (failedUpperBound !== undefined) {
+      state.currentBatchSize = failedUpperBound;
+      state.lastFailedBatchSize = failedUpperBound;
+    }
+    state.error = failure.message;
+    state.latestEnd = Date.now();
+    state.limitingMetric = limitingMetric;
+    await ctx.db.patch("migrations", state._id, state);
     return getMigrationState(ctx, state);
   },
 });
@@ -223,6 +675,7 @@ export const getStatus = query({
                 .unique()) ?? {
                 name: m,
                 processed: 0,
+                currentRangeIndex: 0,
                 cursor: null,
                 latestStart: 0,
                 workerId: undefined,
@@ -242,6 +695,94 @@ export const getStatus = query({
     );
   },
 });
+
+async function scheduleWorker(
+  ctx: MutationCtx,
+  state: Doc<"migrations">,
+  args: WorkerScheduleArgs,
+): Promise<void> {
+  const workerGeneration = (state.workerGeneration ?? 0) + 1;
+  state.workerId = await ctx.scheduler.runAfter(0, runWorkerFunction, {
+    ...args,
+    workerGeneration,
+  });
+  state.workerGeneration = workerGeneration;
+}
+
+async function claimWorker(
+  ctx: MutationCtx,
+  state: Doc<"migrations">,
+  workerGeneration: number,
+): Promise<boolean> {
+  if (state.workerGeneration === workerGeneration) {
+    if (state.workerId === undefined) {
+      return true;
+    }
+    const worker = await ctx.db.system.get(
+      "_scheduled_functions",
+      state.workerId,
+    );
+    return (
+      worker !== null &&
+      (worker.state.kind === "pending" || worker.state.kind === "inProgress")
+    );
+  }
+  if (
+    state.workerGeneration !== undefined &&
+    state.workerGeneration > workerGeneration
+  ) {
+    return false;
+  }
+  const storedWorker = state.workerId
+    ? await ctx.db.system.get("_scheduled_functions", state.workerId)
+    : null;
+  if (
+    storedWorker !== null &&
+    (storedWorker.state.kind === "pending" ||
+      storedWorker.state.kind === "inProgress")
+  ) {
+    return false;
+  }
+  state.workerGeneration = workerGeneration;
+  return true;
+}
+
+function classifyWorkerFailure(error: unknown): WorkerFailure {
+  const message = error instanceof Error ? error.message : String(error);
+  const transactionLimitMetric = getTransactionLimitMetric(error);
+  if (transactionLimitMetric !== undefined) {
+    return {
+      kind: "transactionLimit",
+      limitingMetric: transactionLimitMetric,
+      message,
+    };
+  }
+  if (looksLikeSystemOperationsTimeout(error)) {
+    return { kind: "systemOperationsTimeout", message };
+  }
+  if (looksLikeExecutionTimeout(error)) {
+    return { kind: "executionTimeout", message };
+  }
+  if (looksLikeOccError(error)) {
+    return { kind: "occ", message };
+  }
+  return { kind: "unknown", message };
+}
+
+function getWorkerFailureMetric(failure: WorkerFailure): string | undefined {
+  switch (failure.kind) {
+    case "transactionLimit":
+      return failure.limitingMetric;
+    case "executionTimeout":
+      return MUTATION_USER_EXECUTION_TIME_METRIC;
+    case "systemOperationsTimeout":
+      return MUTATION_SYSTEM_OPERATIONS_TIME_METRIC;
+    case "occ":
+      return OCC_LIMITING_METRIC;
+    case "unknown":
+      return undefined;
+  }
+}
 
 async function getMigrationState(
   ctx: QueryCtx,
@@ -270,10 +811,48 @@ async function getMigrationState(
     isDone: migration.isDone,
     latestStart: migration.latestStart,
     latestEnd: migration.latestEnd,
-    error: migration.error,
+    error:
+      migration.error ??
+      (worker?.state.kind === "failed" ? worker.state.error : undefined),
     state,
-    batchSize: args?.batchSize,
+    batchSize: args?.batchSize ?? migration.currentBatchSize,
+    limitingMetric: migration.limitingMetric,
+    currentRangeIndex:
+      args?.currentRangeIndex ?? migration.currentRangeIndex ?? 0,
     next: args?.next?.map((n: { name: string }) => n.name),
+  };
+}
+
+type MigrationBatchFailure = {
+  batchSize: number;
+  message: string;
+};
+
+function getMigrationBatchFailure(
+  error: unknown,
+): MigrationBatchFailure | undefined {
+  if (!(error instanceof ConvexError)) {
+    return undefined;
+  }
+  const data: unknown = error.data;
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const record = data as Record<string, unknown>;
+  if (record.kind !== MIGRATION_BATCH_FAILURE) {
+    return undefined;
+  }
+  if (
+    typeof record.batchSize !== "number" ||
+    !Number.isInteger(record.batchSize) ||
+    record.batchSize <= 0 ||
+    typeof record.message !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    batchSize: record.batchSize,
+    message: record.message,
   };
 }
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -7,11 +7,19 @@ export default defineSchema({
     cursor: v.union(v.string(), v.null()),
     isDone: v.boolean(),
     workerId: v.optional(v.id("_scheduled_functions")),
+    workerGeneration: v.optional(v.number()),
     error: v.optional(v.string()),
     // The number of documents processed so far.
     processed: v.number(),
+    // 0-based position in the customRange list when a migration has multiple ranges.
+    currentRangeIndex: v.optional(v.number()),
     latestStart: v.number(),
     latestEnd: v.optional(v.number()),
+    // Adaptive batch-size state. Missing on rows written by older versions.
+    currentBatchSize: v.optional(v.number()),
+    lastFailedBatchSize: v.optional(v.number()),
+    // TransactionMetrics key that most recently caused an adaptive shrink.
+    limitingMetric: v.optional(v.string()),
   })
     .index("name", ["name"])
     .index("isDone", ["isDone"]),

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,7 @@
-import { type Infer, type ObjectType, v } from "convex/values";
+import type { TransactionMetrics } from "convex/server";
+import { ConvexError, type Infer, type ObjectType, v } from "convex/values";
+
+export const MIGRATION_BATCH_FAILURE = "MigrationBatchFailure";
 
 export const migrationArgs = {
   fn: v.optional(v.string()),
@@ -8,13 +11,21 @@ export const migrationArgs = {
   next: v.optional(v.array(v.string())),
   reset: v.optional(v.boolean()),
   oneBatchOnly: v.optional(v.boolean()),
+  // 0-based position in the customRange list when a migration has multiple ranges.
+  currentRangeIndex: v.optional(v.number()),
 };
 export type MigrationArgs = ObjectType<typeof migrationArgs>;
 
 export type MigrationResult = {
-  continueCursor: string;
+  // `null` starts the next batch from the beginning, used when advancing to
+  // the next customRange entry.
+  continueCursor: string | null;
   isDone: boolean;
   processed: number;
+  // 0-based position in the customRange list when a migration has multiple ranges.
+  currentRangeIndex?: number;
+  batchSize?: number;
+  metrics?: TransactionMetrics;
 };
 
 export const migrationStatus = v.object({
@@ -33,6 +44,41 @@ export const migrationStatus = v.object({
   latestStart: v.number(),
   latestEnd: v.optional(v.number()),
   batchSize: v.optional(v.number()),
+  limitingMetric: v.optional(v.string()),
+  // 0-based position in the customRange list when a migration has multiple ranges.
+  currentRangeIndex: v.number(),
   next: v.optional(v.array(v.string())),
 });
 export type MigrationStatus = Infer<typeof migrationStatus>;
+
+export function getMigrationDryRunResult(
+  error: unknown,
+): MigrationResult | undefined {
+  return getMigrationDryRunObjectField(error, "result") as
+    | MigrationResult
+    | undefined;
+}
+
+export function getMigrationDryRunStatus(
+  error: unknown,
+): MigrationStatus | undefined {
+  return getMigrationDryRunObjectField(error, "status") as
+    | MigrationStatus
+    | undefined;
+}
+
+function getMigrationDryRunObjectField(
+  error: unknown,
+  field: "result" | "status",
+): Record<string, unknown> | undefined {
+  const data = error instanceof ConvexError ? error.data : undefined;
+  if (!isRecord(data) || data.kind !== "DRY RUN") {
+    return undefined;
+  }
+  const value = data[field];
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

This PR adds three related capabilities to the migrations component:

1. Adaptive batch sizing from successful transaction metrics and observed wall time.
2. Automatic smaller-batch recovery for recognized capacity failures.
3. Sequential migration over multiple indexed `customRange` ranges.

Operational motivation and a worked sizing example are in [More convenient Convex migrations](https://convex-in-prod.github.io/posts/convenient-convex-migrations/). This description focuses on implementation details, recovery semantics, and limitations.

## Adaptive batch sizing

When a run does not pass an explicit `batchSize`, its starting size uses this precedence:

1. The migration definition's `batchSize`.
2. The `Migrations` instance's `defaultBatchSize`.
3. `100`.

After every successful full batch, the component examines every metric returned by `getTransactionMetrics()`. For each metric:

```text
usedRatio = used / (used + remaining)
```

It also measures wall time around the nested migration mutation and treats:

```text
wallTimeRatio = durationMs / 1000
```

as another sizing signal. The one-second denominator comes from Convex's documented mutation execution limit.

The tightest ratio controls the next size. The target utilization is `0.5`:

```text
nextSize ≈ floor(currentSize * 0.5 / tightestRatio)
```

Growth occurs only when the estimated cost of adding another document remains within the target. A successful batch above the target shrinks toward the target.

The wall timer is deliberately conservative. It includes nested-function and database syscall waiting, but excludes the enclosing controller's remaining work, commit time, and top-level OCC retries. It is not presented as Convex user-execution time.

The component persists:

- `currentBatchSize`
- `lastFailedBatchSize`
- `limitingMetric`

`getStatus()` returns the active batch size, current range, and limiting metric. Wall-time reductions use `mutationWallTime`.

A known failed size acts as an exclusive upper bound for later growth. Growth approaches that bound without retrying it directly. A successful run at or above a stale failed bound clears the bound.

Underfilled pages do not update adaptive sizing. A short final page measures fewer documents than requested and is not representative of either the requested size or the first page of a subsequent range.

Passing an explicit run-level `batchSize` disables successful-batch adaptation for that run. Recognized failures can still reduce it.

## Failure recovery

There are two failure paths.

### Failures from the nested application migration

The component controller mutation calls the application migration mutation and catches only failures from that nested call. The catch does not include state updates, continuation scheduling, or serial-migration handoff.

Recognized transaction-limit failures reduce the batch size. The classifier covers:

- documents read
- bytes read
- database queries
- documents written
- bytes written
- scheduled-function count
- scheduled-function argument bytes

The `TooManyWrites` short code is intentionally not sufficient to classify `documentsWritten`, because Convex also uses it for the deployment-wide write-throughput limiter. The component matches the unique per-function-execution write-limit message instead.

Migration wrappers attach the attempted size to nested failures because an aborted mutation cannot return its normal result or transaction metrics.

### Failures from the complete controller transaction

Scheduled continuations now use this topology:

```text
internal worker action
  -> component controller mutation
       -> application migration mutation
       -> migration state update
       -> schedule next worker
  <- catch aborted controller transaction
  -> recovery mutation
```

The action boundary can observe failures reported only after the complete controller transaction aborts, including:

- permanent OCC after Convex exhausts its transaction retries
- mutation user-execution timeout
- cumulative system-operations timeout
- transaction-limit failures reported at the outer mutation boundary

Application writes, cursor advancement, adaptive state, and continuation scheduling belong to the same transaction. A failed controller transaction commits none of them.

For a recognized failure, recovery halves the smallest known failed size:

```text
nextSize = max(1, floor(failedUpperBound / 2))
```

There is no binary search against the last successful size. Retries can go below the configured/default size. A recognized failure at size `1` is terminal.

Unknown outer failures are not retried as capacity failures. Recovery records a generic error and stops; the original error remains in Convex function logs.

The limiting labels for failures without returned metrics are:

- `optimisticConcurrencyControl`
- `mutationUserExecutionTime`
- `mutationSystemOperationsTime`

## Worker ownership and races

Scheduled workers carry a monotonically increasing generation together with their expected cursor, range index, and batch size.

Before applying recovery, the component verifies that the failed worker still owns the stored migration position. Reset, cancellation, manual resume, or a newer worker invalidates the old generation. Late recovery from an invalidated worker becomes a no-op instead of reducing or overwriting newer progress.

External `oneBatchOnly` calls also do not run beside an active scheduled worker.

A recognized failed attempt does not consume `oneBatchOnly`: smaller retries continue until one batch commits or size `1` fails.

## Direct-call limitation

The first `runOne()` call remains a mutation for API compatibility. The component cannot automatically catch a commit-time OCC failure or hard timeout outside that top-level mutation.

The caller can retry with a smaller explicit size. `runToCompletion()` already executes from an action and performs the same halving policy when it knows the attempted size.

When `runToCompletion()` starts from an explicit cursor, callers should also pass `batchSize` if the first attempt needs outer-failure recovery. Otherwise the action does not know the failed attempt's resolved definition/default size.

After the first successful controller call, `runToCompletion()` omits its original explicit cursor and resumes stored progress. This prevents a long-running action from repeatedly submitting a stale cursor after another worker advances the migration.

## Multiple custom ranges

`customRange` may now return either one query or a non-empty ordered array of queries:

```ts
customRange: (query) => [
  query.withIndex("by_status", (q) => q.eq("status", "pending")),
  query.withIndex("by_status", (q) => q.eq("status", "running")),
]
```

Ranges execute sequentially. When one range completes, the component increments `currentRangeIndex`, resets the cursor to `null`, and starts the next range. `isDone` becomes true only after the final range.

A cursor belongs to one range. Explicit resume in a range after the first therefore requires both `cursor` and `currentRangeIndex`. Reset returns to range `0`.

`runToCompletion()` tracks both values and can resume from stored multi-range progress.

## Compatibility

Existing public call shapes remain accepted. New status fields and component-state fields are additive.

The new persisted fields are optional, so existing component rows do not require a migration when adopting this version.

Rolling back after the component has written the new fields is different: the previous component schema does not accept them. A rollback requires removing those fields from component state first.

## Coverage

Tests cover:

- metric- and wall-time-based growth and shrinkage
- failed-size bounds and halving
- nested and outer failure classification
- OCC and both timeout classes
- stale worker recovery after reset, cancellation, and manual resume
- `oneBatchOnly` recovery
- preservation of adaptive state on underfilled range pages
- multi-range cursor/range transitions and resume
- `runToCompletion()` stale-cursor and failed-size behavior
- serial migration handoff failures remaining outside the nested batch catch
