### PR TITLE
feat: add create CLI with --rename-field/--rename-table scaffolding

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,7 @@ export default [
   // Convex code - Worker environment
   {
     files: ["src/**/*.{ts,tsx}", "example/convex/**/*.{ts,tsx}"],
-    ignores: ["src/react/**"],
+    ignores: ["src/react/**", "src/cli.ts", "src/cli/**"],
     languageOptions: {
       globals: globals.worker,
     },
@@ -61,6 +61,22 @@ export default [
           allowShortCircuit: true,
           allowTernary: true,
           allowTaggedTemplates: true,
+        },
+      ],
+    },
+  },
+  // CLI code - Node environment
+  {
+    files: ["src/cli.ts", "src/cli/**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@convex-dev/migrations",
       "version": "0.3.5",
       "license": "Apache-2.0",
+      "bin": {
+        "convex-migrations": "dist/cli.js"
+      },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "2.0.0",
         "@edge-runtime/vm": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "component"
   ],
   "type": "module",
+  "bin": {
+    "convex-migrations": "./dist/cli.js"
+  },
   "scripts": {
     "dev": "convex dev --start 'npm run dev:build'",
     "dev:frontend": "cd example && vite --clearScreen false",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+import { main } from "./cli/main.js";
+
+const exitCode = await main();
+if (exitCode !== 0) {
+  process.exitCode = exitCode;
+}

--- a/src/cli/generator.test.ts
+++ b/src/cli/generator.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+import {
+  renderMigrationFile,
+  renderRenameFieldMigration,
+  renderRenameTableMigration,
+} from "./generator.js";
+
+describe("migration scaffold generator", () => {
+  test("renders rename-field migration contents", () => {
+    const migration = renderRenameFieldMigration({
+      table: "users",
+      oldField: "oldName",
+      newField: "newName",
+    });
+
+    expect(migration.name).toBe("renameUsersOldNameToNewName");
+    expect(renderMigrationFile(migration.definition)).toBe(`import { Migrations } from "@convex-dev/migrations";
+import { components } from "./_generated/api.js";
+import { internalMutation } from "./_generated/server.js";
+import schema from "./schema.js";
+
+export const migrations = new Migrations(components.migrations, {
+  internalMutation,
+  schema,
+});
+
+export const renameUsersOldNameToNewName = migrations.define({
+  table: "users",
+  migrateOne: (_ctx, doc) => {
+    if (doc.oldName === undefined) {
+      return;
+    }
+    return {
+      newName: doc.oldName,
+      oldName: undefined,
+    };
+  },
+});
+`);
+  });
+
+  test("renders rename-table migration contents", () => {
+    const migration = renderRenameTableMigration({
+      oldTable: "oldUsers",
+      newTable: "users",
+    });
+
+    expect(migration.name).toBe("renameOldUsersToUsers");
+    expect(renderMigrationFile(migration.definition)).toBe(`import { Migrations } from "@convex-dev/migrations";
+import { components } from "./_generated/api.js";
+import { internalMutation } from "./_generated/server.js";
+import schema from "./schema.js";
+
+export const migrations = new Migrations(components.migrations, {
+  internalMutation,
+  schema,
+});
+
+export const renameOldUsersToUsers = migrations.define({
+  table: "oldUsers",
+  migrateOne: async (ctx, doc) => {
+    const { _id: oldId, _creationTime: _oldCreationTime, ...newDoc } = doc;
+    await ctx.db.insert("users", newDoc);
+    await ctx.db.delete(oldId);
+  },
+});
+`);
+  });
+});

--- a/src/cli/generator.ts
+++ b/src/cli/generator.ts
@@ -1,0 +1,221 @@
+export type RenameFieldSpec = {
+  table: string;
+  oldField: string;
+  newField: string;
+  name?: string;
+};
+
+export type RenameTableSpec = {
+  oldTable: string;
+  newTable: string;
+  name?: string;
+};
+
+export type CustomMigrationSpec = {
+  table: string;
+  name?: string;
+};
+
+export type GeneratedMigration = {
+  name: string;
+  operation: "renameField" | "renameTable" | "custom";
+  definition: string;
+};
+
+const reservedWords = new Set([
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "export",
+  "extends",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+const identifierPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+export function parseRenameFieldSpec(input: string): RenameFieldSpec {
+  const match = input.trim().match(/^([^.=]+)\.([^.=]+)=([^=]+)$/);
+  if (!match) {
+    throw new Error(
+      `Expected --rename-field in the form table.oldField=newField, got ${JSON.stringify(input)}`,
+    );
+  }
+  return {
+    table: requireValue(match[1], "table"),
+    oldField: requireValue(match[2], "old field"),
+    newField: requireValue(match[3], "new field"),
+  };
+}
+
+export function parseRenameTableSpec(input: string): RenameTableSpec {
+  const match = input.trim().match(/^([^=]+)=([^=]+)$/);
+  if (!match) {
+    throw new Error(
+      `Expected --rename-table in the form oldTable=newTable, got ${JSON.stringify(input)}`,
+    );
+  }
+  return {
+    oldTable: requireValue(match[1], "old table"),
+    newTable: requireValue(match[2], "new table"),
+  };
+}
+
+export function renderRenameFieldMigration(
+  spec: RenameFieldSpec,
+): GeneratedMigration {
+  const table = requireValue(spec.table, "table");
+  const oldField = requireValue(spec.oldField, "old field");
+  const newField = requireValue(spec.newField, "new field");
+  if (oldField === newField) {
+    throw new Error("Old and new field names must be different");
+  }
+  const name =
+    spec.name ??
+    toExportName(
+      `rename${toPascalCase(table)}${toPascalCase(oldField)}To${toPascalCase(
+        newField,
+      )}`,
+    );
+  const oldRead = fieldRead("doc", oldField);
+  const definition = `export const ${toExportName(name)} = migrations.define({
+  table: ${quote(table)},
+  migrateOne: (_ctx, doc) => {
+    if (${oldRead} === undefined) {
+      return;
+    }
+    return {
+      ${fieldKey(newField)}: ${oldRead},
+      ${fieldKey(oldField)}: undefined,
+    };
+  },
+});`;
+  return { name: toExportName(name), operation: "renameField", definition };
+}
+
+export function renderRenameTableMigration(
+  spec: RenameTableSpec,
+): GeneratedMigration {
+  const oldTable = requireValue(spec.oldTable, "old table");
+  const newTable = requireValue(spec.newTable, "new table");
+  if (oldTable === newTable) {
+    throw new Error("Old and new table names must be different");
+  }
+  const name =
+    spec.name ??
+    toExportName(
+      `rename${toPascalCase(oldTable)}To${toPascalCase(newTable)}`,
+    );
+  const definition = `export const ${toExportName(name)} = migrations.define({
+  table: ${quote(oldTable)},
+  migrateOne: async (ctx, doc) => {
+    const { _id: oldId, _creationTime: _oldCreationTime, ...newDoc } = doc;
+    await ctx.db.insert(${quote(newTable)}, newDoc);
+    await ctx.db.delete(oldId);
+  },
+});`;
+  return { name: toExportName(name), operation: "renameTable", definition };
+}
+
+export function renderCustomMigration(
+  spec: CustomMigrationSpec,
+): GeneratedMigration {
+  const table = requireValue(spec.table, "table");
+  const name = toExportName(spec.name ?? `migrate${toPascalCase(table)}`);
+  const definition = `export const ${name} = migrations.define({
+  table: ${quote(table)},
+  migrateOne: async (_ctx, _doc) => {
+  },
+});`;
+  return { name, operation: "custom", definition };
+}
+
+export function renderMigrationFile(definition: string): string {
+  return `import { Migrations } from "@convex-dev/migrations";
+import { components } from "./_generated/api.js";
+import { internalMutation } from "./_generated/server.js";
+import schema from "./schema.js";
+
+export const migrations = new Migrations(components.migrations, {
+  internalMutation,
+  schema,
+});
+
+${definition}
+`;
+}
+
+export function toExportName(input: string): string {
+  const trimmed = input.trim();
+  if (identifierPattern.test(trimmed) && !reservedWords.has(trimmed)) {
+    return trimmed;
+  }
+  const fallback = lowerFirst(toPascalCase(trimmed));
+  if (identifierPattern.test(fallback) && !reservedWords.has(fallback)) {
+    return fallback;
+  }
+  return `migration${toPascalCase(trimmed)}`;
+}
+
+function requireValue(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`Missing ${label}`);
+  }
+  return trimmed;
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}
+
+function fieldRead(base: string, field: string): string {
+  return identifierPattern.test(field)
+    ? `${base}.${field}`
+    : `${base}[${quote(field)}]`;
+}
+
+function fieldKey(field: string): string {
+  return identifierPattern.test(field) ? field : `[${quote(field)}]`;
+}
+
+function toPascalCase(input: string): string {
+  const words = input
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean);
+  const pascal = words
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join("");
+  return pascal || "Migration";
+}
+
+function lowerFirst(input: string): string {
+  return input.charAt(0).toLowerCase() + input.slice(1);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,405 @@
+/// <reference types="node" />
+import { constants } from "node:fs";
+import {
+  access,
+  appendFile,
+  mkdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+import {
+  type CustomMigrationSpec,
+  type GeneratedMigration,
+  type RenameFieldSpec,
+  type RenameTableSpec,
+  parseRenameFieldSpec,
+  parseRenameTableSpec,
+  renderCustomMigration,
+  renderMigrationFile,
+  renderRenameFieldMigration,
+  renderRenameTableMigration,
+  toExportName,
+} from "./generator.js";
+
+type CliIO = {
+  cwd: string;
+  stdin: Readable & { isTTY?: boolean };
+  stdout: Writable;
+  stderr: Writable;
+};
+
+type ParsedArgs = {
+  command?: string;
+  help: boolean;
+  json: boolean;
+  name?: string;
+  renameField?: string;
+  renameTable?: string;
+};
+
+type ComponentState = {
+  installed: boolean;
+  configPath?: string;
+};
+
+type CreateMigrationResult = {
+  path: string;
+  migration: string;
+  operation: GeneratedMigration["operation"];
+  action: "created" | "updated";
+  componentInstalled: boolean;
+  setupRequired: boolean;
+  run: string;
+  setupSteps?: string;
+};
+
+const setupSteps = `Install and configure the migrations component:
+
+  npm install @convex-dev/migrations
+
+Create convex/convex.config.ts if it does not exist, then add:
+
+  import { defineApp } from "convex/server";
+  import migrations from "@convex-dev/migrations/convex.config.js";
+
+  const app = defineApp();
+  app.use(migrations);
+
+  export default app;`;
+
+export async function main(
+  args = process.argv.slice(2),
+  io: CliIO = {
+    cwd: process.cwd(),
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  },
+): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args);
+  } catch (error) {
+    writeLine(io.stderr, errorMessage(error));
+    writeLine(io.stderr, "");
+    writeLine(io.stderr, helpText());
+    return 1;
+  }
+
+  if (parsed.help || !parsed.command) {
+    writeLine(io.stdout, helpText());
+    return 0;
+  }
+
+  if (parsed.command !== "create") {
+    writeLine(io.stderr, `Unknown command ${JSON.stringify(parsed.command)}`);
+    writeLine(io.stderr, "");
+    writeLine(io.stderr, helpText());
+    return 1;
+  }
+
+  try {
+    const request = await buildCreateRequest(parsed, io);
+    const result = await createMigration(request, io.cwd);
+    if (parsed.json) {
+      writeLine(io.stdout, JSON.stringify(result, null, 2));
+    } else {
+      if (result.setupRequired) {
+        writeLine(io.stderr, "");
+        writeLine(io.stderr, setupSteps);
+        writeLine(io.stderr, "");
+      }
+      writeLine(
+        io.stdout,
+        `${capitalize(result.action)} ${result.path} with ${result.migration}`,
+      );
+      writeLine(io.stdout, `Run it with: ${result.run}`);
+    }
+    return 0;
+  } catch (error) {
+    if (parsed.json) {
+      writeLine(
+        io.stdout,
+        JSON.stringify({ ok: false, error: errorMessage(error) }, null, 2),
+      );
+    } else {
+      writeLine(io.stderr, errorMessage(error));
+    }
+    return 1;
+  }
+}
+
+async function createMigration(
+  migration: GeneratedMigration,
+  cwd: string,
+): Promise<CreateMigrationResult> {
+  const convexDir = path.join(cwd, "convex");
+  const dirStat = await stat(convexDir).catch(() => undefined);
+  if (!dirStat?.isDirectory()) {
+    throw new Error(
+      "Could not find a convex/ directory. Run this command from the root of a Convex app.",
+    );
+  }
+
+  const filePath = path.join(convexDir, "migrations.ts");
+  const relativePath = path.relative(cwd, filePath);
+  const componentState = await detectComponentState(cwd);
+  const fileExists = await exists(filePath);
+  let action: "created" | "updated";
+
+  if (fileExists) {
+    const current = await readFile(filePath, "utf8");
+    if (hasExport(current, migration.name)) {
+      throw new Error(`${relativePath} already exports ${migration.name}`);
+    }
+    if (!current.includes("new Migrations(")) {
+      throw new Error(
+        `${relativePath} exists, but it does not initialize @convex-dev/migrations. Add the Migrations setup from the README before appending generated migrations.`,
+      );
+    }
+    await appendFile(
+      filePath,
+      appendBlock(current, migration.definition),
+      "utf8",
+    );
+    action = "updated";
+  } else {
+    await mkdir(convexDir, { recursive: true });
+    await writeFile(filePath, renderMigrationFile(migration.definition), "utf8");
+    action = "created";
+  }
+
+  return {
+    path: relativePath,
+    migration: migration.name,
+    operation: migration.operation,
+    action,
+    componentInstalled: componentState.installed,
+    setupRequired: !componentState.installed,
+    run: `npx convex run migrations:${migration.name}`,
+    setupSteps: componentState.installed ? undefined : setupSteps,
+  };
+}
+
+async function buildCreateRequest(
+  parsed: ParsedArgs,
+  io: CliIO,
+): Promise<GeneratedMigration> {
+  if (parsed.renameField && parsed.renameTable) {
+    throw new Error("Specify only one of --rename-field or --rename-table");
+  }
+
+  if (parsed.renameField) {
+    const spec = parseRenameFieldSpec(parsed.renameField);
+    return renderRenameFieldMigration({ ...spec, name: parsed.name });
+  }
+  if (parsed.renameTable) {
+    const spec = parseRenameTableSpec(parsed.renameTable);
+    return renderRenameTableMigration({ ...spec, name: parsed.name });
+  }
+
+  if (!io.stdin.isTTY) {
+    throw new Error(
+      "Missing migration type. Pass --rename-field table.old=new or --rename-table old=new, or run in an interactive terminal.",
+    );
+  }
+
+  return promptForMigration(parsed.name, io);
+}
+
+async function promptForMigration(
+  name: string | undefined,
+  io: CliIO,
+): Promise<GeneratedMigration> {
+  const rl = createInterface({ input: io.stdin, output: io.stderr });
+  try {
+    const kindAnswer = await rl.question(
+      "Migration type [rename-field, rename-table, custom] (rename-field): ",
+    );
+    const kind = normalizeKind(kindAnswer || "rename-field");
+    if (kind === "rename-field") {
+      const answer = await rl.question(
+        "Field rename (table.oldField=newField): ",
+      );
+      const spec: RenameFieldSpec = parseRenameFieldSpec(answer);
+      return renderRenameFieldMigration({
+        ...spec,
+        name: await promptName(rl, name, () =>
+          renderRenameFieldMigration(spec).name,
+        ),
+      });
+    }
+    if (kind === "rename-table") {
+      const answer = await rl.question("Table rename (oldTable=newTable): ");
+      const spec: RenameTableSpec = parseRenameTableSpec(answer);
+      return renderRenameTableMigration({
+        ...spec,
+        name: await promptName(rl, name, () =>
+          renderRenameTableMigration(spec).name,
+        ),
+      });
+    }
+    const table = await rl.question("Table to migrate: ");
+    const spec: CustomMigrationSpec = { table };
+    return renderCustomMigration({
+      ...spec,
+      name: await promptName(rl, name, () => renderCustomMigration(spec).name),
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptName(
+  rl: ReturnType<typeof createInterface>,
+  provided: string | undefined,
+  defaultName: () => string,
+): Promise<string> {
+  if (provided) {
+    return toExportName(provided);
+  }
+  const fallback = defaultName();
+  const answer = await rl.question(`Export name (${fallback}): `);
+  return toExportName(answer || fallback);
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { help: false, json: false };
+  const rest = [...args];
+  if (rest[0] && !rest[0].startsWith("-")) {
+    parsed.command = rest.shift();
+  }
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--rename-field") {
+      parsed.renameField = takeValue(rest, i, arg);
+      i += 1;
+    } else if (arg.startsWith("--rename-field=")) {
+      parsed.renameField = arg.slice("--rename-field=".length);
+    } else if (arg === "--rename-table") {
+      parsed.renameTable = takeValue(rest, i, arg);
+      i += 1;
+    } else if (arg.startsWith("--rename-table=")) {
+      parsed.renameTable = arg.slice("--rename-table=".length);
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option ${arg}`);
+    } else if (!parsed.name) {
+      parsed.name = arg;
+    } else {
+      throw new Error(`Unexpected argument ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function detectComponentState(cwd: string): Promise<ComponentState> {
+  const candidates = [
+    path.join(cwd, "convex", "convex.config.ts"),
+    path.join(cwd, "convex", "convex.config.js"),
+    path.join(cwd, "convex", "convex.config.mts"),
+    path.join(cwd, "convex", "convex.config.mjs"),
+  ];
+  for (const configPath of candidates) {
+    if (!(await exists(configPath))) {
+      continue;
+    }
+    const contents = await readFile(configPath, "utf8");
+    return {
+      configPath,
+      installed:
+        contents.includes("@convex-dev/migrations/convex.config") ||
+        /app\.use\(\s*migrations\s*\)/.test(contents),
+    };
+  }
+  return { installed: false };
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  return access(filePath, constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+function appendBlock(current: string, block: string): string {
+  const separator = current.endsWith("\n\n")
+    ? ""
+    : current.endsWith("\n")
+      ? "\n"
+      : "\n\n";
+  return `${separator}${block}\n`;
+}
+
+function hasExport(contents: string, name: string): boolean {
+  return new RegExp(`\\bexport\\s+const\\s+${escapeRegExp(name)}\\b`).test(
+    contents,
+  );
+}
+
+function takeValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function normalizeKind(
+  kind: string,
+): "rename-field" | "rename-table" | "custom" {
+  const normalized = kind.trim().toLowerCase();
+  if (
+    normalized === "rename-field" ||
+    normalized === "field" ||
+    normalized === "rename field"
+  ) {
+    return "rename-field";
+  }
+  if (
+    normalized === "rename-table" ||
+    normalized === "table" ||
+    normalized === "rename table"
+  ) {
+    return "rename-table";
+  }
+  if (normalized === "custom" || normalized === "blank") {
+    return "custom";
+  }
+  throw new Error(`Unknown migration type ${JSON.stringify(kind)}`);
+}
+
+function helpText(): string {
+  return `Usage:
+  convex-migrations create [name] [--rename-field table.oldField=newField]
+  convex-migrations create [name] [--rename-table oldTable=newTable]
+
+Options:
+  --rename-field <table.old=new>  Scaffold a field rename migration
+  --rename-table <old=new>        Scaffold a table rename migration
+  --json                          Print a JSON success summary
+  -h, --help                      Show this help`;
+}
+
+function writeLine(stream: Writable, text: string): void {
+  stream.write(`${text}\n`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
## Summary

Adds a `create` CLI to the migrations component, per @ianmacartney's suggestion on get-convex/convex-backend#477:

> What do you think about making this a TUI under a CLI command for the migrations component? `npx @convex-dev/migrations create [--rename-field] ...` That seems like the more idiomatic place to put it, and it could then be used by agents similarly. The CLI could also help with scaffolding the component setup if you hadn't installed / added it to your app yet.

## What it does

- `npx @convex-dev/migrations create [name] --rename-field users.oldName=newName` scaffolds a field-rename migration (copy old to new, unset old) without prompting
- `--rename-table old=new` scaffolds the documented table-rename pattern
- No flags: interactive prompts (plain readline, zero new runtime dependencies)
- Missing-component detection: if `convex.config.ts` has no migrations entry, the CLI prints the install/config steps instead of failing opaquely
- `--json` prints a machine-readable success summary so agents can consume it

## Testing

- `npm run build`, `npm run typecheck`, `npm run lint` pass
- Vitest unit tests cover both scaffold generators
- Smoke-tested the built CLI: help, `--rename-field` scaffold generation into a bare project, setup detection, and `--json` output

Refs get-convex/convex-backend#477
