### PR TITLE
use a stale query to short-circuit starting running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Before starting a migration, `runOne`, `runSerially`, and the `runner`
+  functions now check the migration status from a stale snapshot (via
+  `ctx.runQuery(..., { useStaleSnapshot: true })`) and no-op if it's already in
+  progress. This avoids OCC conflicts with the batches an in-progress migration
+  is actively writing, which was likely when re-running a post-deploy script.
+  For a series, it checks *all* the migrations at once (not just the first),
+  since a mid-series migration that's in progress causes the same conflict.
+  Requires `convex@^1.42.0`.
+
 ## 0.3.5
 
 - Supports running migrations within components by using the convex-helpers

--- a/example/convex/example.test.ts
+++ b/example/convex/example.test.ts
@@ -3,6 +3,7 @@ import { initConvexTest } from "./setup.test";
 import { components, internal } from "./_generated/api";
 import { runToCompletion } from "@convex-dev/migrations";
 import { createFunctionHandle, getFunctionName } from "convex/server";
+import { migrations } from "./example";
 
 describe("example", () => {
   beforeEach(async () => {
@@ -48,6 +49,85 @@ describe("example", () => {
         );
       }),
     ).rejects.toThrow("This migration fails after the first");
+  });
+
+  test("runOne no-ops when the migration is already in progress", async () => {
+    const t = initConvexTest();
+    await t.mutation(internal.example.seed, { count: 10 });
+    // batchSize 2 over 10 docs runs one batch and schedules a worker for the
+    // next, leaving the migration in progress (a pending worker).
+    const first = await t.run((ctx) =>
+      migrations.runOne(ctx, internal.example.setDefaultValue, {
+        batchSize: 2,
+      }),
+    );
+    expect(first?.state).toBe("inProgress");
+    expect(first?.processed).toBe(2);
+    // A second attempt while it's in progress should bail without running
+    // another batch (which would OCC against the in-flight batches).
+    const second = await t.run((ctx) =>
+      migrations.runOne(ctx, internal.example.setDefaultValue, {
+        batchSize: 2,
+      }),
+    );
+    expect(second?.state).toBe("inProgress");
+    expect(second?.processed).toBe(first?.processed);
+  });
+
+  test("runSerially no-ops when the first migration is already in progress", async () => {
+    const t = initConvexTest();
+    await t.mutation(internal.example.seed, { count: 10 });
+    const first = await t.run((ctx) =>
+      migrations.runOne(ctx, internal.example.setDefaultValue, {
+        batchSize: 2,
+      }),
+    );
+    expect(first?.state).toBe("inProgress");
+    // Re-running the series (e.g. a re-invoked post-deploy script) should
+    // detect the in-progress migration and no-op rather than restart it.
+    const second = await t.run((ctx) =>
+      migrations.runSerially(ctx, [
+        internal.example.setDefaultValue,
+        internal.example.validateRequiredField,
+      ]),
+    );
+    expect(second?.name).toBe(getFunctionName(internal.example.setDefaultValue));
+    expect(second?.state).toBe("inProgress");
+    expect(second?.processed).toBe(first?.processed);
+  });
+
+  test("runSerially no-ops when a later migration in the series is in progress", async () => {
+    const t = initConvexTest();
+    await t.mutation(internal.example.seed, { count: 10 });
+    // Put a *later* migration in the series in progress (a pending worker).
+    const started = await t.run((ctx) =>
+      migrations.runOne(ctx, internal.example.setDefaultValue, {
+        batchSize: 2,
+      }),
+    );
+    expect(started?.state).toBe("inProgress");
+    // Run a series whose *first* migration isn't in progress, but a later one
+    // is. `migrate` would walk the series and read the in-progress migration's
+    // hot state row (an OCC risk), so we should detect it and bail without
+    // running the first migration at all.
+    const result = await t.run((ctx) =>
+      migrations.runSerially(ctx, [
+        internal.example.clearField,
+        internal.example.setDefaultValue,
+      ]),
+    );
+    expect(result?.name).toBe(
+      getFunctionName(internal.example.setDefaultValue),
+    );
+    expect(result?.state).toBe("inProgress");
+    // The first migration in the series never ran (else its state would exist).
+    const [clearFieldStatus] = await t.run((ctx) =>
+      migrations.getStatus(ctx, {
+        migrations: [internal.example.clearField],
+      }),
+    );
+    expect(clearFieldStatus.state).toBe("unknown");
+    expect(clearFieldStatus.isDone).toBe(false);
   });
 
   test("test migrating with function handle", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.2",
         "chokidar-cli": "3.0.0",
-        "convex": "1.39.1",
+        "convex": "1.42.3",
         "convex-helpers": "0.1.118",
         "convex-test": "0.0.53",
         "eslint": "9.39.4",
@@ -36,7 +36,7 @@
         "vitest": "4.1.7"
       },
       "peerDependencies": {
-        "convex": "^1.35.0",
+        "convex": "^1.42.0",
         "convex-helpers": "^0.1.115"
       }
     },
@@ -2208,15 +2208,15 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.39.1.tgz",
-      "integrity": "sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ==",
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.3.tgz",
+      "integrity": "sha512-7Tz/lH6UlZdiqzLPF/zrlH6Rlo/DOp836dL+GZkUMEQ2jaGGNnBIiIDcOOiEqtfSehuQ65r/rdNMnb4LupowaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -6432,9 +6432,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "peerDependencies": {
-    "convex": "^1.35.0",
+    "convex": "^1.42.0",
     "convex-helpers": "^0.1.115"
   },
   "devDependencies": {
@@ -70,7 +70,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "chokidar-cli": "3.0.0",
-    "convex": "1.39.1",
+    "convex": "1.42.3",
     "convex-helpers": "0.1.118",
     "convex-test": "0.0.53",
     "eslint": "9.39.4",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -179,6 +179,44 @@ export class Migrations<
     });
   }
 
+  /**
+   * Checks whether any of the given migrations is already running before we try
+   * to start them, so the caller can bail instead of provoking an OCC conflict
+   * with the batches an in-progress migration is actively writing. This is a
+   * common problem when re-running migrations from a deploy script.
+   *
+   * We check all the names because starting a series attempts each migration in
+   * turn, so any one being in progress can conflict - not just the first. A
+   * serial series is self-propagating (each migration starts the next when it
+   * finishes), so bailing still lets the in-flight series run to completion.
+   *
+   * From a mutation we read from a stale snapshot so this check itself doesn't
+   * add a read dependency that would conflict. useStaleSnapshot only applies
+   * inside a mutation transaction; an action runs each query in its own
+   * transaction, so there's no calling transaction to protect.
+   *
+   * Note: a migration may have just finished by the time this transaction
+   * commits, but that's fine - the goal is only to avoid starting it again, and
+   * a completed migration is a no-op to start anyway.
+   *
+   * @returns The status of an in-progress migration, if any, else undefined.
+   */
+  private async anyInProgress(
+    ctx: MutationCtx | ActionCtx,
+    names: string[],
+  ): Promise<MigrationStatus | undefined> {
+    const { type } = await ctx.meta.getFunctionMetadata();
+    const statuses =
+      type === "mutation"
+        ? await (ctx as MutationCtx).runQuery(
+            this.component.lib.getStatus,
+            { names },
+            { useStaleSnapshot: true },
+          )
+        : await ctx.runQuery(this.component.lib.getStatus, { names });
+    return statuses.find((s) => s.state === "inProgress");
+  }
+
   private async _runInteractive(
     ctx: MutationCtx | ActionCtx,
     args: MigrationArgs,
@@ -211,6 +249,24 @@ export class Migrations<
           })),
         ),
       );
+    }
+    // Bail if any migration in the series is already running, to avoid an OCC
+    // conflict with its batches. Unless we're resetting, which explicitly asks
+    // to restart from the beginning.
+    if (!args.reset) {
+      const inProgress = await this.anyInProgress(ctx, [
+        name,
+        ...(next ?? []).map((n) => n.name),
+      ]);
+      if (inProgress) {
+        const { componentPath } = await getFunctionMetadata();
+        return logStatusAndInstructions(
+          inProgress.name,
+          inProgress,
+          args,
+          componentPath,
+        );
+      }
     }
     // Handle reset option: reset sets cursor to null for all migrations
     const cursor = args.reset ? null : args.cursor;
@@ -539,8 +595,15 @@ export class Migrations<
       reset?: boolean;
     },
   ) {
+    const name = getFunctionName(fnRef);
+    // Bail if it's already running to avoid an OCC conflict with its batches.
+    // Skip this when resetting, which explicitly asks to restart.
+    if (!opts?.reset) {
+      const inProgress = await this.anyInProgress(ctx, [name]);
+      if (inProgress) return inProgress;
+    }
     return ctx.runMutation(this.component.lib.migrate, {
-      name: getFunctionName(fnRef),
+      name,
       fnHandle: await createFunctionHandle(fnRef),
       cursor: opts?.reset ? null : opts?.cursor,
       batchSize: opts?.batchSize,
@@ -590,6 +653,15 @@ export class Migrations<
   ) {
     if (fnRefs.length === 0) return;
     const [fnRef, ...rest] = fnRefs;
+    const name = getFunctionName(fnRef);
+    // Bail if any migration in the series is already running, to avoid an OCC
+    // conflict with its batches - the common case when re-running a post-deploy
+    // script.
+    const inProgress = await this.anyInProgress(
+      ctx,
+      fnRefs.map(getFunctionName),
+    );
+    if (inProgress) return inProgress;
     const next = await Promise.all(
       rest.map(async (fnRef) => ({
         name: getFunctionName(fnRef),
@@ -597,7 +669,7 @@ export class Migrations<
       })),
     );
     return ctx.runMutation(this.component.lib.migrate, {
-      name: getFunctionName(fnRef),
+      name,
       fnHandle: await createFunctionHandle(fnRef),
       next,
       dryRun: false,
@@ -785,11 +857,11 @@ export function isNewFormatCursor(cursor: string | null): boolean {
 type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
 type MutationCtx = Pick<
   GenericMutationCtx<GenericDataModel>,
-  "runQuery" | "runMutation"
+  "runQuery" | "runMutation" | "meta"
 >;
 type ActionCtx = Pick<
   GenericActionCtx<GenericDataModel>,
-  "runQuery" | "runMutation" | "storage"
+  "runQuery" | "runMutation" | "storage" | "meta"
 >;
 
 // TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+


### PR DESCRIPTION
Avoid trying to start migrations that are underway by using a stale query before starting them